### PR TITLE
Upgrade from 0.7.9 to 0.7.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .idea/
 .eslintcache
+
+foundryconfig.json

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 3) En VSCode, añadir la carpeta del repositorio al worskpace (boton derecho en el panel izquierda y "Add folder to workspace" por ejemplo). Luego, hacer clic derecho sobre ella y "Open in integrated terminal". Eso abre una terminal de comandos de windows en dicho directorio (...\FoundryVTT\Data\systems\AnimaBeyondFoundry). En esa terminal se debe ejecutar el comando:
 
+4) Duplica el fichero `foundryconfig.example.json` y renombralo a `foundryconfig.json`, luego editalo y el campo `dataPath` rellenalo con la ruta donde tengas la carpeta data, por ejemplo:
+4.1. Windows: `C:/Users/<nombredeUsuario>/AppData/Local/FoundryVTT`
+4.2. Linux: `/home/<nombredeUsuario>/.local/share/FoundryVTT`
+
 `npm install`
 
 4) Hasta ahora esta carpeta no tiene ningún efecto sobre Foundry. Para generar la carpeta real del sistema, ejecutamos el comando:

--- a/foundryconfig.example.json
+++ b/foundryconfig.example.json
@@ -1,0 +1,5 @@
+{
+  "dataPath": "",
+  "repository": "https://github.com/Guote/AnimaBeyondFoundry",
+  "rawURL": "https://raw.githubusercontent.com/Guote/AnimaBeyondFoundry/develop/src/system.json?token=ABZDWT3PAZGSJMXL7HJY3P3AZWZBI"
+}

--- a/foundryconfig.json
+++ b/foundryconfig.json
@@ -1,5 +1,0 @@
-{
-  "dataPath": "",
-  "repository": "",
-  "rawURL": ""
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -890,9 +890,9 @@
       }
     },
     "@league-of-foundry-developers/foundry-vtt-types": {
-      "version": "0.7.9-6",
-      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-0.7.9-6.tgz",
-      "integrity": "sha512-NdLNuzLGTCU8fA94JLUiOHrAMlE8NOa2YA2wc+Q27ljf+ZFPxjhwnp80e8uUryQI4CNb+O0ldPpTXnSAz7AAKA==",
+      "version": "0.7.10-0",
+      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-0.7.10-0.tgz",
+      "integrity": "sha512-Lo1rtkVAeHYPLxmuh8bh5gzNsg5Qh7ccc22rhN7mDgxnh07T7mXTm0J5nRFuFPZ3krLnepXsE64hjgmzYMm31w==",
       "dev": true,
       "requires": {
         "@types/howler": "2.2.1",
@@ -903,449 +903,6 @@
         "pixi.js": "5.3.4",
         "tinymce": "5.6.2",
         "typescript": "^4.1.4"
-      },
-      "dependencies": {
-        "@pixi/accessibility": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.4.tgz",
-          "integrity": "sha512-g8hQnnVSYJ+gLrdQyCsDDSu+VehhVL9Pcr2fkQSC9VBhxiMIN+Paky8kOxC2LL5nsKRIUGGaTa6iHtiopPQQMw==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/app": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.4.tgz",
-          "integrity": "sha512-XT/EFyGslFdvdHY9ZS7yDAdLOj0U1UHeLxFr1kwiawuwIt/WsxNeH4jq2IijvZuQ3L5ON7Y7zQf54JEPv5fK0Q==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4"
-          }
-        },
-        "@pixi/constants": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.4.tgz",
-          "integrity": "sha512-YsWjdMVMoJA8kG/0D4s9/DWWa2lPlexk0qNZOcV3tICaPG0IYfIhepfveMeMhIb0QrdSAsPbhYdcaxxgoaNF1A==",
-          "dev": true
-        },
-        "@pixi/core": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.4.tgz",
-          "integrity": "sha512-k6SRniy4pH7ZKAKC2HkbLSKPm+j7bF17fTO5+6xLSiVqLnfa7ChV51wNuoa30olVF3/d8ME2uraf7dsvXwomzw==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/runner": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/ticker": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/display": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.4.tgz",
-          "integrity": "sha512-RCi39Qi1L8mlIu1YvWvPI45WpKHRbpYlvSIT/414wmoaAoFZnaJ+qoVuqDCfzfNhWWirGAWpXniQjNRzkUZjcA==",
-          "dev": true,
-          "requires": {
-            "@pixi/math": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/extract": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.4.tgz",
-          "integrity": "sha512-HTGF5WKts4kF0v1rOU4YcLMUpb18FzcxKhaCwjXpqm3vANgjuGAUL9PxpmC4ecS03mkRa0+9vAXEUkJLQeNLPg==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/filter-alpha": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.4.tgz",
-          "integrity": "sha512-lgRCN8bDeHlMpRtQv/P5gCJ+9e3AufJVC2H0TdkCRmJqm1dB+rhKwxIeNINsjjz+kiuumOe88CxRbRd3CpEydg==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4"
-          }
-        },
-        "@pixi/filter-blur": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.4.tgz",
-          "integrity": "sha512-PYPHc8MEsZWfmVQkm0UKO70dmZpcWyu/Bs0xJa5apsmCm6zXNzXfMh02lsXu82HrNQ+9iJT/mAKrrDABGn9vtg==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/settings": "5.3.4"
-          }
-        },
-        "@pixi/filter-color-matrix": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.4.tgz",
-          "integrity": "sha512-9Iflvr1moc7ns5A/73lWVwLUbe+wb678NLA4X9SYXAJTiij4M1isDrULhk95TGUaWo4bbSBaov1vm8XbUZNG8w==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4"
-          }
-        },
-        "@pixi/filter-displacement": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.4.tgz",
-          "integrity": "sha512-CldemXpcKr1GRT1Ll33TTFWtU6KDl4sYTvAwWTAEu8OhKedobBB/mRCIK9p1h7iZYtaj5MRYQjewmFKRrqyXrQ==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/math": "5.3.4"
-          }
-        },
-        "@pixi/filter-fxaa": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.4.tgz",
-          "integrity": "sha512-GtIfaOsqQlsK+F1795V/JJIq5Uu15nasiCwGr+wVwHNGMBanAXt7AnSy8JHcgup3Eqx8FXRuM/AyD/4IYUquuA==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4"
-          }
-        },
-        "@pixi/filter-noise": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.4.tgz",
-          "integrity": "sha512-pNq4T4LC2naWz0pZXF3RT9aA7XdLL4TuBjJsYrrBaJZraupbOo6Mp8VwxVJs8GThmMl7/U13GalOzVSb/HjzDg==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4"
-          }
-        },
-        "@pixi/graphics": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.4.tgz",
-          "integrity": "sha512-W6cuFfzwgfx3zVFICu98cENgwjy+d2e6xNJ/yJI0q8QiwlZmpuSXHBCfZrtIWpp9VSJZe2KDIo1LUnLhCpp3Yg==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/sprite": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/interaction": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.4.tgz",
-          "integrity": "sha512-7/JN7AtCuYmmWczrQROKSI9Z42p6C6p7B2wDVqNYYgROSaeGbGsZ8H0sa6nYLnIj4F3CaGSRoRnAMPz+CO70bw==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/ticker": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/loaders": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.4.tgz",
-          "integrity": "sha512-/dFznZnsivzq/MW7n/PPhMeznWFMMDYrac958OlxzSwrEAgtq6ZVLZbz7pCf9uhiifMnqwBGefphOFubj3Qorw==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/utils": "5.3.4",
-            "resource-loader": "^3.0.1"
-          }
-        },
-        "@pixi/math": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.4.tgz",
-          "integrity": "sha512-UQ2jhdlCHIvAVf8EcHB3QuR5GhB49VdTccWmer96RZCeGkcZsPSUk1ldO1GZnIctcf0Iuvmq74G02dYbtC7JxQ==",
-          "dev": true
-        },
-        "@pixi/mesh": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.4.tgz",
-          "integrity": "sha512-y0Y52cwsqETc/35DMGVCzQmhPCrQ3ZhjWcW9JwQoHMy3PoNSN9QUqYjVjF2oEj5hxcJnGNo3GAXFZz2Uh/UReQ==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/mesh-extras": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.4.tgz",
-          "integrity": "sha512-mjc3RlgLGYUv2FUKrVv/Dfaj2KW5qhX9c6Ev+yJ4lg/sMblet5gtYuyKsmJMS/K6B8V8+oMlTfX9ozFCzq1oJQ==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/core": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/mesh": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/mixin-cache-as-bitmap": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.4.tgz",
-          "integrity": "sha512-8ZAmzDK1fHXIzYFHFH72LUMRZerY1Pt71XI3UgsWExABS1aREe20oPLuVByLP94W7X/kTXz+zK+nt51O5MGKsA==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/sprite": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/mixin-get-child-by-name": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.4.tgz",
-          "integrity": "sha512-PY1Qe6CKYu+UNSRAFIfRyhRfkrpsTMwh9sI6iXVVi712bM3JkZIwDfDF31TA4nYX8z7H49w+KCWY4PejZ8l2WA==",
-          "dev": true,
-          "requires": {
-            "@pixi/display": "5.3.4"
-          }
-        },
-        "@pixi/mixin-get-global-position": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.4.tgz",
-          "integrity": "sha512-yv+huwUAOfyXDEHbQp6W5/3RjQpwG6AhpgMY4b3XBMtvrp9R/5Wgw/YC/nea9kZ3Gb2u4Aqeco8U+tPIRNjeIA==",
-          "dev": true,
-          "requires": {
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4"
-          }
-        },
-        "@pixi/particles": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.4.tgz",
-          "integrity": "sha512-sX0BGGbS7yCwlam1mC5awW2BjU7QFmZv82E8ON/r9aAZS6InT25zOpMdvy0ImIIqBvF0Z1Qz1IT6pKEBxqMo9Q==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/polyfill": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.4.tgz",
-          "integrity": "sha512-bxk8bhrfQ9Y2rU/L0ss2gIeXwmMlOciw+B5yVUDVLqzjE4y8Fm2619L4qu9v51Z9a+8JbyVE5c1eT7HJgx0g0w==",
-          "dev": true,
-          "requires": {
-            "es6-promise-polyfill": "^1.2.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "@pixi/prepare": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.4.tgz",
-          "integrity": "sha512-MVMvNTrNYQidWXd4LSkgv+eqTzHtSViADA+Tvnemy9QMuWqbTfxFn4UMhrBjQIfG9+hwdIFS14pfFKt/BLHNrw==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/graphics": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/text": "5.3.4",
-            "@pixi/ticker": "5.3.4"
-          }
-        },
-        "@pixi/runner": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.4.tgz",
-          "integrity": "sha512-iPWHVhv2js+NhDQNmePkHfic8SilBT7H/pzRjMqHqvafTdl8Y+4g+hdQDalZJNr3Ixl77QPAYlOKhegBujn2mQ==",
-          "dev": true
-        },
-        "@pixi/settings": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.4.tgz",
-          "integrity": "sha512-Jqj1NLtYODCqK8ZKVccUBAaBDkn7SQ6b7N15FwxbiSgfbvwpynSKr6WQTxqMq29h42MKsic6BJcQrlGEbDNz5w==",
-          "dev": true,
-          "requires": {
-            "ismobilejs": "^1.1.0"
-          }
-        },
-        "@pixi/sprite": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.4.tgz",
-          "integrity": "sha512-vO+GMJWnumnVzc2R7jGcLlUeIXIek+SDqVQyPDPJ5T8sWTgFhanHCrgpKfplZIu08X/zvIZQxPfd332R0waeog==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/sprite-animated": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.4.tgz",
-          "integrity": "sha512-HaTelbvm2xekw9b9GdYbupM2RZ/muRZvstkmSqMZhiIViZekzKPa5WQJwnqZzVBjCg735j09G8aF4H2NpNqF9g==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/sprite": "5.3.4",
-            "@pixi/ticker": "5.3.4"
-          }
-        },
-        "@pixi/sprite-tiling": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.4.tgz",
-          "integrity": "sha512-NMqpNuWEIic2n5EL/TrGmn1+bab4TwxcILnco4myvw9Sd/wLsaJx3XboegY7YCWCKhnl+Ax6cl8DMkk7OJkpJQ==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/sprite": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/spritesheet": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.4.tgz",
-          "integrity": "sha512-gfCqOMD2XJHw1bMXxXbuYPnBbCBUvbzMN7Pw2po7U5R6bsk7WEoG7Hp3HjAPyPQvg36v2Db6dcz0//ZNNqm+EQ==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/loaders": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/text": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.4.tgz",
-          "integrity": "sha512-kmdK1KLrWY8PHGIIXKVRQmik3gWquiYz6DB0jqabi3j0gVp6h+CVDje01N6Nl75ZCQ/PjaWafzQvURypfX73ng==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/sprite": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/text-bitmap": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.4.tgz",
-          "integrity": "sha512-uNJOYvy3sn0S5Bp6H113ZAmaQm68ojCXSuOBJzIMEV2cUuYLngW+7DqKOsHMMhNmcONs/OBq57SRrzDcr8WYdw==",
-          "dev": true,
-          "requires": {
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/loaders": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/mesh": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/text": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        },
-        "@pixi/ticker": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.4.tgz",
-          "integrity": "sha512-PmCAstgyI6vLPXKZVFlo4Zornry21BwFiTOp1dBUW3sIMky9Wx2fajjyVHIridCY6yaazt6Xu37khZf5qRgASw==",
-          "dev": true,
-          "requires": {
-            "@pixi/settings": "5.3.4"
-          }
-        },
-        "@pixi/utils": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.4.tgz",
-          "integrity": "sha512-HjUWFfAmPPKX0BSq20GWY//Vm+gC9O+wcn9sXMqOItCuf0DDFwxoBrUVaHNNnEVhM1Djpz/+YijCijmGdZeddA==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "earcut": "^2.1.5",
-            "eventemitter3": "^3.1.0",
-            "url": "^0.11.0"
-          }
-        },
-        "@types/jquery": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.1.tgz",
-          "integrity": "sha512-Tyctjh56U7eX2b9udu3wG853ASYP0uagChJcQJXLUXEU6C/JiW5qt5dl8ao01VRj1i5pgXPAf8f1mq4+FDLRQg==",
-          "dev": true,
-          "requires": {
-            "@types/sizzle": "*"
-          }
-        },
-        "handlebars": {
-          "version": "4.7.6",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-          "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5",
-            "neo-async": "^2.6.0",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4",
-            "wordwrap": "^1.0.0"
-          }
-        },
-        "pixi.js": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.4.tgz",
-          "integrity": "sha512-CrAaQQRw+iTA75IEu57CEk6stFs587iWE3HwQG0rZL2ESW2uJvdsF/ieeS/hFk35QmlEsPRqmH1sf7t7FGtsyw==",
-          "dev": true,
-          "requires": {
-            "@pixi/accessibility": "5.3.4",
-            "@pixi/app": "5.3.4",
-            "@pixi/constants": "5.3.4",
-            "@pixi/core": "5.3.4",
-            "@pixi/display": "5.3.4",
-            "@pixi/extract": "5.3.4",
-            "@pixi/filter-alpha": "5.3.4",
-            "@pixi/filter-blur": "5.3.4",
-            "@pixi/filter-color-matrix": "5.3.4",
-            "@pixi/filter-displacement": "5.3.4",
-            "@pixi/filter-fxaa": "5.3.4",
-            "@pixi/filter-noise": "5.3.4",
-            "@pixi/graphics": "5.3.4",
-            "@pixi/interaction": "5.3.4",
-            "@pixi/loaders": "5.3.4",
-            "@pixi/math": "5.3.4",
-            "@pixi/mesh": "5.3.4",
-            "@pixi/mesh-extras": "5.3.4",
-            "@pixi/mixin-cache-as-bitmap": "5.3.4",
-            "@pixi/mixin-get-child-by-name": "5.3.4",
-            "@pixi/mixin-get-global-position": "5.3.4",
-            "@pixi/particles": "5.3.4",
-            "@pixi/polyfill": "5.3.4",
-            "@pixi/prepare": "5.3.4",
-            "@pixi/runner": "5.3.4",
-            "@pixi/settings": "5.3.4",
-            "@pixi/sprite": "5.3.4",
-            "@pixi/sprite-animated": "5.3.4",
-            "@pixi/sprite-tiling": "5.3.4",
-            "@pixi/spritesheet": "5.3.4",
-            "@pixi/text": "5.3.4",
-            "@pixi/text-bitmap": "5.3.4",
-            "@pixi/ticker": "5.3.4",
-            "@pixi/utils": "5.3.4"
-          }
-        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -1372,6 +929,383 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
+      }
+    },
+    "@pixi/accessibility": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.4.tgz",
+      "integrity": "sha512-g8hQnnVSYJ+gLrdQyCsDDSu+VehhVL9Pcr2fkQSC9VBhxiMIN+Paky8kOxC2LL5nsKRIUGGaTa6iHtiopPQQMw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/app": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.4.tgz",
+      "integrity": "sha512-XT/EFyGslFdvdHY9ZS7yDAdLOj0U1UHeLxFr1kwiawuwIt/WsxNeH4jq2IijvZuQ3L5ON7Y7zQf54JEPv5fK0Q==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4"
+      }
+    },
+    "@pixi/constants": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.4.tgz",
+      "integrity": "sha512-YsWjdMVMoJA8kG/0D4s9/DWWa2lPlexk0qNZOcV3tICaPG0IYfIhepfveMeMhIb0QrdSAsPbhYdcaxxgoaNF1A==",
+      "dev": true
+    },
+    "@pixi/core": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.4.tgz",
+      "integrity": "sha512-k6SRniy4pH7ZKAKC2HkbLSKPm+j7bF17fTO5+6xLSiVqLnfa7ChV51wNuoa30olVF3/d8ME2uraf7dsvXwomzw==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/runner": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/ticker": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/display": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.4.tgz",
+      "integrity": "sha512-RCi39Qi1L8mlIu1YvWvPI45WpKHRbpYlvSIT/414wmoaAoFZnaJ+qoVuqDCfzfNhWWirGAWpXniQjNRzkUZjcA==",
+      "dev": true,
+      "requires": {
+        "@pixi/math": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/extract": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.4.tgz",
+      "integrity": "sha512-HTGF5WKts4kF0v1rOU4YcLMUpb18FzcxKhaCwjXpqm3vANgjuGAUL9PxpmC4ecS03mkRa0+9vAXEUkJLQeNLPg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/filter-alpha": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.4.tgz",
+      "integrity": "sha512-lgRCN8bDeHlMpRtQv/P5gCJ+9e3AufJVC2H0TdkCRmJqm1dB+rhKwxIeNINsjjz+kiuumOe88CxRbRd3CpEydg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4"
+      }
+    },
+    "@pixi/filter-blur": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.4.tgz",
+      "integrity": "sha512-PYPHc8MEsZWfmVQkm0UKO70dmZpcWyu/Bs0xJa5apsmCm6zXNzXfMh02lsXu82HrNQ+9iJT/mAKrrDABGn9vtg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/settings": "5.3.4"
+      }
+    },
+    "@pixi/filter-color-matrix": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.4.tgz",
+      "integrity": "sha512-9Iflvr1moc7ns5A/73lWVwLUbe+wb678NLA4X9SYXAJTiij4M1isDrULhk95TGUaWo4bbSBaov1vm8XbUZNG8w==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4"
+      }
+    },
+    "@pixi/filter-displacement": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.4.tgz",
+      "integrity": "sha512-CldemXpcKr1GRT1Ll33TTFWtU6KDl4sYTvAwWTAEu8OhKedobBB/mRCIK9p1h7iZYtaj5MRYQjewmFKRrqyXrQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/math": "5.3.4"
+      }
+    },
+    "@pixi/filter-fxaa": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.4.tgz",
+      "integrity": "sha512-GtIfaOsqQlsK+F1795V/JJIq5Uu15nasiCwGr+wVwHNGMBanAXt7AnSy8JHcgup3Eqx8FXRuM/AyD/4IYUquuA==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4"
+      }
+    },
+    "@pixi/filter-noise": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.4.tgz",
+      "integrity": "sha512-pNq4T4LC2naWz0pZXF3RT9aA7XdLL4TuBjJsYrrBaJZraupbOo6Mp8VwxVJs8GThmMl7/U13GalOzVSb/HjzDg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4"
+      }
+    },
+    "@pixi/graphics": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.4.tgz",
+      "integrity": "sha512-W6cuFfzwgfx3zVFICu98cENgwjy+d2e6xNJ/yJI0q8QiwlZmpuSXHBCfZrtIWpp9VSJZe2KDIo1LUnLhCpp3Yg==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/sprite": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/interaction": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.4.tgz",
+      "integrity": "sha512-7/JN7AtCuYmmWczrQROKSI9Z42p6C6p7B2wDVqNYYgROSaeGbGsZ8H0sa6nYLnIj4F3CaGSRoRnAMPz+CO70bw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/ticker": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/loaders": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.4.tgz",
+      "integrity": "sha512-/dFznZnsivzq/MW7n/PPhMeznWFMMDYrac958OlxzSwrEAgtq6ZVLZbz7pCf9uhiifMnqwBGefphOFubj3Qorw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/utils": "5.3.4",
+        "resource-loader": "^3.0.1"
+      }
+    },
+    "@pixi/math": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.4.tgz",
+      "integrity": "sha512-UQ2jhdlCHIvAVf8EcHB3QuR5GhB49VdTccWmer96RZCeGkcZsPSUk1ldO1GZnIctcf0Iuvmq74G02dYbtC7JxQ==",
+      "dev": true
+    },
+    "@pixi/mesh": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.4.tgz",
+      "integrity": "sha512-y0Y52cwsqETc/35DMGVCzQmhPCrQ3ZhjWcW9JwQoHMy3PoNSN9QUqYjVjF2oEj5hxcJnGNo3GAXFZz2Uh/UReQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/mesh-extras": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.4.tgz",
+      "integrity": "sha512-mjc3RlgLGYUv2FUKrVv/Dfaj2KW5qhX9c6Ev+yJ4lg/sMblet5gtYuyKsmJMS/K6B8V8+oMlTfX9ozFCzq1oJQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/core": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/mesh": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/mixin-cache-as-bitmap": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.4.tgz",
+      "integrity": "sha512-8ZAmzDK1fHXIzYFHFH72LUMRZerY1Pt71XI3UgsWExABS1aREe20oPLuVByLP94W7X/kTXz+zK+nt51O5MGKsA==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/sprite": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/mixin-get-child-by-name": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.4.tgz",
+      "integrity": "sha512-PY1Qe6CKYu+UNSRAFIfRyhRfkrpsTMwh9sI6iXVVi712bM3JkZIwDfDF31TA4nYX8z7H49w+KCWY4PejZ8l2WA==",
+      "dev": true,
+      "requires": {
+        "@pixi/display": "5.3.4"
+      }
+    },
+    "@pixi/mixin-get-global-position": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.4.tgz",
+      "integrity": "sha512-yv+huwUAOfyXDEHbQp6W5/3RjQpwG6AhpgMY4b3XBMtvrp9R/5Wgw/YC/nea9kZ3Gb2u4Aqeco8U+tPIRNjeIA==",
+      "dev": true,
+      "requires": {
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4"
+      }
+    },
+    "@pixi/particles": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.4.tgz",
+      "integrity": "sha512-sX0BGGbS7yCwlam1mC5awW2BjU7QFmZv82E8ON/r9aAZS6InT25zOpMdvy0ImIIqBvF0Z1Qz1IT6pKEBxqMo9Q==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/polyfill": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.4.tgz",
+      "integrity": "sha512-bxk8bhrfQ9Y2rU/L0ss2gIeXwmMlOciw+B5yVUDVLqzjE4y8Fm2619L4qu9v51Z9a+8JbyVE5c1eT7HJgx0g0w==",
+      "dev": true,
+      "requires": {
+        "es6-promise-polyfill": "^1.2.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@pixi/prepare": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.4.tgz",
+      "integrity": "sha512-MVMvNTrNYQidWXd4LSkgv+eqTzHtSViADA+Tvnemy9QMuWqbTfxFn4UMhrBjQIfG9+hwdIFS14pfFKt/BLHNrw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/graphics": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/text": "5.3.4",
+        "@pixi/ticker": "5.3.4"
+      }
+    },
+    "@pixi/runner": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.4.tgz",
+      "integrity": "sha512-iPWHVhv2js+NhDQNmePkHfic8SilBT7H/pzRjMqHqvafTdl8Y+4g+hdQDalZJNr3Ixl77QPAYlOKhegBujn2mQ==",
+      "dev": true
+    },
+    "@pixi/settings": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.4.tgz",
+      "integrity": "sha512-Jqj1NLtYODCqK8ZKVccUBAaBDkn7SQ6b7N15FwxbiSgfbvwpynSKr6WQTxqMq29h42MKsic6BJcQrlGEbDNz5w==",
+      "dev": true,
+      "requires": {
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "@pixi/sprite": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.4.tgz",
+      "integrity": "sha512-vO+GMJWnumnVzc2R7jGcLlUeIXIek+SDqVQyPDPJ5T8sWTgFhanHCrgpKfplZIu08X/zvIZQxPfd332R0waeog==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/sprite-animated": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.4.tgz",
+      "integrity": "sha512-HaTelbvm2xekw9b9GdYbupM2RZ/muRZvstkmSqMZhiIViZekzKPa5WQJwnqZzVBjCg735j09G8aF4H2NpNqF9g==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/sprite": "5.3.4",
+        "@pixi/ticker": "5.3.4"
+      }
+    },
+    "@pixi/sprite-tiling": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.4.tgz",
+      "integrity": "sha512-NMqpNuWEIic2n5EL/TrGmn1+bab4TwxcILnco4myvw9Sd/wLsaJx3XboegY7YCWCKhnl+Ax6cl8DMkk7OJkpJQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/sprite": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/spritesheet": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.4.tgz",
+      "integrity": "sha512-gfCqOMD2XJHw1bMXxXbuYPnBbCBUvbzMN7Pw2po7U5R6bsk7WEoG7Hp3HjAPyPQvg36v2Db6dcz0//ZNNqm+EQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/loaders": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/text": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.4.tgz",
+      "integrity": "sha512-kmdK1KLrWY8PHGIIXKVRQmik3gWquiYz6DB0jqabi3j0gVp6h+CVDje01N6Nl75ZCQ/PjaWafzQvURypfX73ng==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/sprite": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/text-bitmap": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.4.tgz",
+      "integrity": "sha512-uNJOYvy3sn0S5Bp6H113ZAmaQm68ojCXSuOBJzIMEV2cUuYLngW+7DqKOsHMMhNmcONs/OBq57SRrzDcr8WYdw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/loaders": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/mesh": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/text": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
+    },
+    "@pixi/ticker": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.4.tgz",
+      "integrity": "sha512-PmCAstgyI6vLPXKZVFlo4Zornry21BwFiTOp1dBUW3sIMky9Wx2fajjyVHIridCY6yaazt6Xu37khZf5qRgASw==",
+      "dev": true,
+      "requires": {
+        "@pixi/settings": "5.3.4"
+      }
+    },
+    "@pixi/utils": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.4.tgz",
+      "integrity": "sha512-HjUWFfAmPPKX0BSq20GWY//Vm+gC9O+wcn9sXMqOItCuf0DDFwxoBrUVaHNNnEVhM1Djpz/+YijCijmGdZeddA==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "earcut": "^2.1.5",
+        "eventemitter3": "^3.1.0",
+        "url": "^0.11.0"
       }
     },
     "@sinonjs/commons": {
@@ -1482,6 +1416,15 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/jquery": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-Tyctjh56U7eX2b9udu3wG853ASYP0uagChJcQJXLUXEU6C/JiW5qt5dl8ao01VRj1i5pgXPAf8f1mq4+FDLRQg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -1519,9 +1462,9 @@
       "dev": true
     },
     "@types/sizzle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
     },
     "@types/socket.io-client": {
@@ -5667,6 +5610,19 @@
         "glogg": "^1.0.0"
       }
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -9420,10 +9376,52 @@
       }
     },
     "pixi-particles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/pixi-particles/-/pixi-particles-4.3.0.tgz",
-      "integrity": "sha512-3G66vSFMbp+LnD3P6SYIxOo3f1X3yxkPbP1Tr2o+o18ZkkT6mePpCvsPUrM8s+xCW7oK816/wDYZXMtKzJ61CQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/pixi-particles/-/pixi-particles-4.3.1.tgz",
+      "integrity": "sha512-XSqDFgYwm/7FRCgP5I2Fc57d98qvb1ql/x4uTjdP4uXDUGgjdO8OW/2A0HVWS1CkOht/1x6dQzsM1oCJAUlaow==",
       "dev": true
+    },
+    "pixi.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.4.tgz",
+      "integrity": "sha512-CrAaQQRw+iTA75IEu57CEk6stFs587iWE3HwQG0rZL2ESW2uJvdsF/ieeS/hFk35QmlEsPRqmH1sf7t7FGtsyw==",
+      "dev": true,
+      "requires": {
+        "@pixi/accessibility": "5.3.4",
+        "@pixi/app": "5.3.4",
+        "@pixi/constants": "5.3.4",
+        "@pixi/core": "5.3.4",
+        "@pixi/display": "5.3.4",
+        "@pixi/extract": "5.3.4",
+        "@pixi/filter-alpha": "5.3.4",
+        "@pixi/filter-blur": "5.3.4",
+        "@pixi/filter-color-matrix": "5.3.4",
+        "@pixi/filter-displacement": "5.3.4",
+        "@pixi/filter-fxaa": "5.3.4",
+        "@pixi/filter-noise": "5.3.4",
+        "@pixi/graphics": "5.3.4",
+        "@pixi/interaction": "5.3.4",
+        "@pixi/loaders": "5.3.4",
+        "@pixi/math": "5.3.4",
+        "@pixi/mesh": "5.3.4",
+        "@pixi/mesh-extras": "5.3.4",
+        "@pixi/mixin-cache-as-bitmap": "5.3.4",
+        "@pixi/mixin-get-child-by-name": "5.3.4",
+        "@pixi/mixin-get-global-position": "5.3.4",
+        "@pixi/particles": "5.3.4",
+        "@pixi/polyfill": "5.3.4",
+        "@pixi/prepare": "5.3.4",
+        "@pixi/runner": "5.3.4",
+        "@pixi/settings": "5.3.4",
+        "@pixi/sprite": "5.3.4",
+        "@pixi/sprite-animated": "5.3.4",
+        "@pixi/sprite-tiling": "5.3.4",
+        "@pixi/spritesheet": "5.3.4",
+        "@pixi/text": "5.3.4",
+        "@pixi/text-bitmap": "5.3.4",
+        "@pixi/ticker": "5.3.4",
+        "@pixi/utils": "5.3.4"
+      }
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -11371,9 +11369,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.1.tgz",
-      "integrity": "sha512-EWhx3fHy3M9JbaeTnO+rEqzCe1wtyQClv6q3YWq0voOj4E+bMZBErVS1GAHPDiRGONYq34M1/d8KuQMgvi6Gjw==",
+      "version": "3.13.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
+      "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@league-of-foundry-developers/foundry-vtt-types": "^0.7.9-6",
+    "@league-of-foundry-developers/foundry-vtt-types": "^0.7.10-0",
     "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",

--- a/src/system.json
+++ b/src/system.json
@@ -5,9 +5,8 @@
   "version": "0.1.0",
   "authors": [
     {
-      "name": "",
-      "email": "",
-      "url": ""
+      "name": "Linkaynn",
+      "url": "https://www.jeseromero.com"
     }
   ],
   "scripts": [],
@@ -29,7 +28,7 @@
   "gridDistance": 1,
   "gridUnits": "m",
   "minimumCoreVersion": "0.5.0",
-  "compatibleCoreVersion": "0.5.0",
+  "compatibleCoreVersion": "0.7.10",
   "url": "",
   "manifest": "",
   "download": "",


### PR DESCRIPTION
Ahora mismo los tipos de Typescript sólo son compatibles con la versión 0.7.10 así que he añadido los campos necesarios para que funcione.

No es para alarmarse, están trabajando en los tipos de 0.8.X y desde mi perspectiva están haciendo un buen trabajo de tipos: https://github.com/League-of-Foundry-Developers/foundry-vtt-types