### PR TITLE
Make resistances rollable with 1d100

### DIFF
--- a/src/templates/actor/parts/header/parts/resistances.hbs
+++ b/src/templates/actor/parts/header/parts/resistances.hbs
@@ -14,6 +14,7 @@
         class="resistance"
         title=(localize (concat 'anima.ui.resistances.' key))
         rollable=true
+        rollableDice='1d100'
         rollableMessage=(localize (concat 'anima.ui.resistances.' key))
         inputName=(concat "data.characteristics.secondaries.resistances." key ".value")
         inputValue=atr.value


### PR DESCRIPTION
Hola,

Esta PR añade la posibilidad de que las resistencias sean roleables.

Se me ocurre que tanto para tiradas de características como tiradas de resistencias hay comportamientos especiales, en el caso de la tirada de resistencia, sacar un 100 implica que superas el check, pase lo que pase. Quizás habría que investigar algo más por ahí.