### PR TITLE
Fix multiple defenses penalizer adding instead of substracting

### DIFF
--- a/src/module/dialogs/combat/CombatDefenseDialog.ts
+++ b/src/module/dialogs/combat/CombatDefenseDialog.ts
@@ -213,7 +213,7 @@ export class CombatDefenseDialog extends FormApplication<FormApplication.Options
           : this.defenderActor.data.data.combat.block.final.value;
 
       const roll = new ABFFoundryRoll(
-        `1d100xa + ${modifier ?? 0} + ${fatigue ?? 0} * 15 - ${multipleDefensesPenalty ?? 0} + ${value}`
+        `1d100xa + ${modifier ?? 0} + ${fatigue ?? 0} * 15 - ${(multipleDefensesPenalty ?? 0) * -1} + ${value}`
       );
 
       roll.roll();


### PR DESCRIPTION
Fixes #73 

La solución permite mantener la UI tal y como estaba, mostrando los penalizadores en negativo y la fórmula del chat sin concatenar símbolos de + y -.