### PR TITLE
Fix: remove 1 movement type point for every -20 action penalizer instead of 1

### DIFF
--- a/src/module/actor/utils/prepareActor/calculations/actor/general/mutateMovementType.ts
+++ b/src/module/actor/utils/prepareActor/calculations/actor/general/mutateMovementType.ts
@@ -9,12 +9,11 @@ export const mutateMovementType = (data: ABFActorDataSourceData) => {
   );
 
   const { movementType } = data.characteristics.secondaries;
-  const negativeMovementModifier = data.general.modifiers.allActions.base.value / 20;
 
   movementType.final.value =
     movementType.mod.value +
     data.characteristics.primaries.agility.value +
-    Math.min(0, Math.sign(negativeMovementModifier) * Math.floor(Math.abs(negativeMovementModifier))) +
+    Math.min(0, Math.ceil(data.general.modifiers.allActions.base.value / 20)) +
     armorsMovementRestrictions;
 
   movementType.final.value = Math.max(0, movementType.final.value);


### PR DESCRIPTION
(Fixes #82)
 
Esta PR arregla el bug que hacía que cada punto de penalización a toda acción quitase un punto al tipo de movimiento. Ahora el cálculo es de 1 de tipo de movimiento por cada 20 de penalizador.