### PR TITLE
Extract distribution config to separate file

### DIFF
--- a/distributionconfig.json
+++ b/distributionconfig.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/AnimaBeyondDevelop/AnimaBeyondFoundry",
+  "rawURL": "https://raw.githubusercontent.com/AnimaBeyondDevelop/AnimaBeyondFoundry"
+}

--- a/foundryconfig.example.json
+++ b/foundryconfig.example.json
@@ -1,5 +1,3 @@
 {
-  "destPath": "",
-  "repository": "https://github.com/AnimaBeyondDevelop/AnimaBeyondFoundry",
-  "rawURL": "https://raw.githubusercontent.com/AnimaBeyondDevelop/AnimaBeyondFoundry"
+  "destPath": ""
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,14 @@ function getConfig() {
   }
 }
 
+function getDistConfig() {
+  const distPath = path.resolve(process.cwd(), 'distributionconfig.json');
+
+  if (fs.pathExistsSync(distPath)) {
+    return fs.readJsonSync(distPath);
+  }
+}
+
 let ROOT_PATH;
 
 if (argv.release) {
@@ -302,15 +310,15 @@ async function packageBuild() {
  */
 function updateManifest(cb) {
   const packageJson = fs.readJSONSync('package.json');
-  const config = getConfig(),
+  const config = getDistConfig(),
     manifest = getManifest(),
     rawURL = config.rawURL,
     repoURL = config.repository,
     manifestRoot = manifest.root;
 
-  if (!config) cb(Error(chalk.red('foundryconfig.json not found')));
+  if (!config) cb(Error(chalk.red('distributionconfig.json not found')));
   if (!manifest) cb(Error(chalk.red('Manifest JSON not found')));
-  if (!rawURL || !repoURL) cb(Error(chalk.red('Repository URLs not configured in foundryconfig.json')));
+  if (!rawURL || !repoURL) cb(Error(chalk.red('Repository URLs not configured in distributionconfig.json')));
 
   try {
     manifest.file.version = packageJson.version;


### PR DESCRIPTION
Esta PR extrae la configuración de publicación a un archivo estático que sí está incluído en control de versiones, de manera que sea más difícil cambiar el repositorio al generar una nueva release.