### PR TITLE
Fix/reset turn

### DIFF
--- a/src/module/combat/ABFCombat.ts
+++ b/src/module/combat/ABFCombat.ts
@@ -21,10 +21,13 @@ export default class ABFCombat extends Combat {
   async rollInitiative(ids: string[] | string, { updateTurn, messageOptions }: InitiativeOptions = {}): Promise<this> {
     const mod = await openModDialog();
 
+    if (typeof ids === 'string') {
+      ids = [ids];
+    }
     for (const id of ids) {
       const combatant = this.data.combatants.get(id);
 
-      super.rollInitiative(id, {
+      await super.rollInitiative(id, {
         formula: `1d100xaturn + ${combatant?.actor?.data.data.characteristics.secondaries.initiative.final.value} + ${mod}`,
         updateTurn,
         messageOptions

--- a/src/module/combat/ABFCombat.ts
+++ b/src/module/combat/ABFCombat.ts
@@ -18,7 +18,7 @@ export default class ABFCombat extends Combat {
   }
 
   // Modify rollInitiative so that it asks for modifiers
-  async rollInitiative(ids: string[] | string, { updateTurn, messageOptions }: InitiativeOptions = {}): Promise<this> {
+  async rollInitiative(ids: string[] | string, { updateTurn = false, messageOptions }: InitiativeOptions = {}): Promise<this> {
     const mod = await openModDialog();
 
     if (typeof ids === 'string') {


### PR DESCRIPTION
There are some small changes on the `rollInitiative` function:

1. The reason why the active PC wasn't the one with highest initiative after `rollInitiative` on a new round was because the `updateTurn` parameter. It defaults to `true`, which means the turn must be updated such that the active player isn't changed by `rollInitiative`. Defaulting to `false` does the trick.
2. When refreshing the page, the initiative of some PC was randomly reset. I think `await`ing for `super.rollInitiative` for all `ids` solves this issue.
3. When given a string as `ids`, we were iterating through its letters which is not the intention.