### PR TITLE
Add mutateDomineData for calculating final values for ki accumulations

### DIFF
--- a/src/module/actor/utils/prepareActor/calculations/actor/domine/mutateDomineData.ts
+++ b/src/module/actor/utils/prepareActor/calculations/actor/domine/mutateDomineData.ts
@@ -1,0 +1,20 @@
+import { ABFActorDataSourceData } from '../../../../../../types/Actor';
+
+export const mutateDomineData = (data: ABFActorDataSourceData) => {
+  const allActionsPenalty = data.general.modifiers.allActions.final.value;
+
+  const { domine } = data;
+  const KI_ACCUMULATIONS = [
+    "strength",
+    "agility",
+    "dexterity",
+    "constitution",
+    "willPower",
+    "power"
+  ];
+
+  for (const accum of KI_ACCUMULATIONS) {
+    domine.kiAccumulation[accum].final.value = Math.max(domine.kiAccumulation[accum].base.value + Math.floor(allActionsPenalty / 20), 0);
+  }
+
+};

--- a/src/module/actor/utils/prepareActor/prepareActor.ts
+++ b/src/module/actor/utils/prepareActor/prepareActor.ts
@@ -13,6 +13,7 @@ import { ABFActorDataSourceData } from '../../../types/Actor';
 import { mutateMovementType } from './calculations/actor/general/mutateMovementType';
 import { mutateMysticData } from './calculations/actor/mystic/mutateMysticData';
 import { mutatePsychicData } from './calculations/actor/psychic/mutatePsychicData';
+import { mutateDomineData } from './calculations/actor/domine/mutateDomineData';
 import { mutateInitiative } from './calculations/actor/mutateInitiative';
 
 // Be careful with order of this functions, some derived data functions could be dependent of another
@@ -29,7 +30,8 @@ const DERIVED_DATA_FUNCTIONS: ((data: ABFActorDataSourceData) => void)[] = [
   mutateWeaponsData,
   mutateInitiative,
   mutateMysticData,
-  mutatePsychicData
+  mutatePsychicData,
+  mutateDomineData,
 ];
 
 export const prepareActor = (actor: ABFActor) => {


### PR DESCRIPTION
In order to fix #89 and calculate final values for ki accumulations a `mutateDomineData` function has been created and added to `prepareActor`.