### PR TITLE
Fix/2hand thrown

### DIFF
--- a/src/module/actor/utils/prepareActor/calculations/items/weapon/util/calculateWeaponStrengthModifier.ts
+++ b/src/module/actor/utils/prepareActor/calculations/items/weapon/util/calculateWeaponStrengthModifier.ts
@@ -5,7 +5,7 @@ import { calculateAttributeModifier } from '../../../util/calculateAttributeModi
 
 export const calculateWeaponStrengthModifier = (weapon: WeaponDataSource, data: ABFActorDataSourceData) => {
   const hasOnlyOneEquippedHandMultiplier =
-    getCurrentEquippedHand(weapon) === WeaponEquippedHandType.ONE_HANDED || weapon.data.isRanged.value;
+    getCurrentEquippedHand(weapon) === WeaponEquippedHandType.ONE_HANDED;
 
   const equippedHandMultiplier = hasOnlyOneEquippedHandMultiplier ? 1 : 2;
 

--- a/src/templates/items/weapon/weapon.hbs
+++ b/src/templates/items/weapon/weapon.hbs
@@ -17,7 +17,7 @@
     {{#> "systems/animabf/templates/common/ui/group-body.hbs"
       class="weapon-item-dialog"
     }}
-      {{#unless (is 'eq' data.data.isRanged.value true)}}
+      {{#unless (and (is 'eq' data.data.isRanged.value true) (is 'eq' data.data.shotType.value 'shot'))}}
         {{> 'systems/animabf/templates/common/ui/custom-select-choices.hbs'
           class="critic-primary"
           isVertical=true


### PR DESCRIPTION
Fixes #95. Damage for thrown weapons should be calculated exactly the same as melee weapons.