### PR TITLE
Migrate types to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "anima-beyond-foundry",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1019,27 +1019,19 @@
       }
     },
     "@league-of-foundry-developers/foundry-vtt-types": {
-      "version": "0.8.9-2",
-      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-0.8.9-2.tgz",
-      "integrity": "sha512-IPPaqPoVbrAqLsYUUFLWllIOpr04Ru36wsfpnDNNWzW9JM9T6s0WyZ2P1DFrKxfojQFlAcmj7PkwY38dVK16Uw==",
+      "version": "9.268.0",
+      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.268.0.tgz",
+      "integrity": "sha512-/rDUEdClBvlsVgKX8YRNBVGeK0zBlYy5DpMKHMXiJMqKFQV2TLecR0Y6u0tQWlo8BEea+yLkYr34stR3zCk0/A==",
       "dev": true,
       "requires": {
-        "@types/jquery": "~3.5.6",
+        "@pixi/graphics-smooth": "0.0.22",
+        "@types/jquery": "~3.5.9",
         "@types/simple-peer": "~9.11.1",
         "handlebars": "4.7.7",
         "pixi-particles": "4.3.1",
-        "pixi.js": "5.3.4",
-        "socket.io-client": "4.1.2",
-        "tinymce": "5.8.1",
-        "typescript": "^4.3.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-          "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
-          "dev": true
-        }
+        "pixi.js": "5.3.11",
+        "socket.io-client": "4.3.2",
+        "tinymce": "5.10.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -1069,245 +1061,251 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.4.tgz",
-      "integrity": "sha512-g8hQnnVSYJ+gLrdQyCsDDSu+VehhVL9Pcr2fkQSC9VBhxiMIN+Paky8kOxC2LL5nsKRIUGGaTa6iHtiopPQQMw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.11.tgz",
+      "integrity": "sha512-/oSizd8/g6KUCeAlknMLJ9CRxBt+vWs6e2DrOctMoRupEHcmhICCjIyAp5GF6RZy9T9gNHDOU5p7vo7qEyVxgQ==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/app": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.4.tgz",
-      "integrity": "sha512-XT/EFyGslFdvdHY9ZS7yDAdLOj0U1UHeLxFr1kwiawuwIt/WsxNeH4jq2IijvZuQ3L5ON7Y7zQf54JEPv5fK0Q==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.11.tgz",
+      "integrity": "sha512-ZWrOjGvVl+lK5OJQT3OqSnSRtU2XgQSe/ULg2uGsSWUqMkJews33JIGOjvk4tIsjm4ekSKiPZRMdYFHzPfgEJg==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11"
       }
     },
     "@pixi/constants": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.4.tgz",
-      "integrity": "sha512-YsWjdMVMoJA8kG/0D4s9/DWWa2lPlexk0qNZOcV3tICaPG0IYfIhepfveMeMhIb0QrdSAsPbhYdcaxxgoaNF1A==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+      "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
       "dev": true
     },
     "@pixi/core": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.4.tgz",
-      "integrity": "sha512-k6SRniy4pH7ZKAKC2HkbLSKPm+j7bF17fTO5+6xLSiVqLnfa7ChV51wNuoa30olVF3/d8ME2uraf7dsvXwomzw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+      "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/runner": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/runner": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/ticker": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/display": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.4.tgz",
-      "integrity": "sha512-RCi39Qi1L8mlIu1YvWvPI45WpKHRbpYlvSIT/414wmoaAoFZnaJ+qoVuqDCfzfNhWWirGAWpXniQjNRzkUZjcA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+      "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
       "dev": true,
       "requires": {
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/extract": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.4.tgz",
-      "integrity": "sha512-HTGF5WKts4kF0v1rOU4YcLMUpb18FzcxKhaCwjXpqm3vANgjuGAUL9PxpmC4ecS03mkRa0+9vAXEUkJLQeNLPg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.11.tgz",
+      "integrity": "sha512-YeBrpIO3E5HUgcdKEldCUqwwDNHm5OBe98YFcdLr5Z0+dQaHnxp9Dm4n75/NojoGb5guYdrV00x+gU2UPHsVdw==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/filter-alpha": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.4.tgz",
-      "integrity": "sha512-lgRCN8bDeHlMpRtQv/P5gCJ+9e3AufJVC2H0TdkCRmJqm1dB+rhKwxIeNINsjjz+kiuumOe88CxRbRd3CpEydg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.11.tgz",
+      "integrity": "sha512-HC4PbiEqDWSi3A715av7knFqD3knSXRxPJKG9mWat2CU9eCizSw+JxXp/okMU/fL4ewooiqQWVU2l1wXOHhVFw==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "5.3.11"
       }
     },
     "@pixi/filter-blur": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.4.tgz",
-      "integrity": "sha512-PYPHc8MEsZWfmVQkm0UKO70dmZpcWyu/Bs0xJa5apsmCm6zXNzXfMh02lsXu82HrNQ+9iJT/mAKrrDABGn9vtg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.11.tgz",
+      "integrity": "sha512-iW5cOMEcDiJidOV95bUfhxdcvwM9JzCoWAd+92gAie8L+ElRSHpu1jxXbKHjo/QczQV1LulOlheyDaJNpaBCDg==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/settings": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/settings": "5.3.11"
       }
     },
     "@pixi/filter-color-matrix": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.4.tgz",
-      "integrity": "sha512-9Iflvr1moc7ns5A/73lWVwLUbe+wb678NLA4X9SYXAJTiij4M1isDrULhk95TGUaWo4bbSBaov1vm8XbUZNG8w==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.11.tgz",
+      "integrity": "sha512-u9NT4+N1I3XV9ygwsmF8/jIwCLqNCLeFOdM4f73kbw/UmakZZ6i6xjjJMc5YFUpC25qDr1TFlqgdGGGHAPl4ug==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "5.3.11"
       }
     },
     "@pixi/filter-displacement": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.4.tgz",
-      "integrity": "sha512-CldemXpcKr1GRT1Ll33TTFWtU6KDl4sYTvAwWTAEu8OhKedobBB/mRCIK9p1h7iZYtaj5MRYQjewmFKRrqyXrQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.11.tgz",
+      "integrity": "sha512-CTIy7C/L9I1X3VNx4nMzQbMFvznsGk2viQh0dSo8r5NLgmaAdxhkGI0KUpNjLBz30278tzFfNuRe59K1y1kHuw==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11"
       }
     },
     "@pixi/filter-fxaa": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.4.tgz",
-      "integrity": "sha512-GtIfaOsqQlsK+F1795V/JJIq5Uu15nasiCwGr+wVwHNGMBanAXt7AnSy8JHcgup3Eqx8FXRuM/AyD/4IYUquuA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.11.tgz",
+      "integrity": "sha512-0ahjui5385e1vRvd7zCc0n5W8ULtNI1uVbDJHP9ueeiF25TKC0GqtZzntNwrQPoU46q8zXdnIGjzMpikbbAasg==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "5.3.11"
       }
     },
     "@pixi/filter-noise": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.4.tgz",
-      "integrity": "sha512-pNq4T4LC2naWz0pZXF3RT9aA7XdLL4TuBjJsYrrBaJZraupbOo6Mp8VwxVJs8GThmMl7/U13GalOzVSb/HjzDg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.11.tgz",
+      "integrity": "sha512-98WC9Nd5u2F03Ned9T3vnbmO/YF1jLSioZ623z9wjqpd5DosZgRtYTSGxjVcXTSfpviIuiJpkyF+X097pbVprg==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "5.3.11"
       }
     },
     "@pixi/graphics": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.4.tgz",
-      "integrity": "sha512-W6cuFfzwgfx3zVFICu98cENgwjy+d2e6xNJ/yJI0q8QiwlZmpuSXHBCfZrtIWpp9VSJZe2KDIo1LUnLhCpp3Yg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
+      "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
+    "@pixi/graphics-smooth": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics-smooth/-/graphics-smooth-0.0.22.tgz",
+      "integrity": "sha512-qq2u+BJBIDBuuSTc2Xzm1D/8RiiKBdxnVDiMb7Go5v8achnV5ctC6m+rf8Mq0sWm66mbOqu1aq/9efT4A4sPrA==",
+      "dev": true
+    },
     "@pixi/interaction": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.4.tgz",
-      "integrity": "sha512-7/JN7AtCuYmmWczrQROKSI9Z42p6C6p7B2wDVqNYYgROSaeGbGsZ8H0sa6nYLnIj4F3CaGSRoRnAMPz+CO70bw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.11.tgz",
+      "integrity": "sha512-n2K99CYyBcrf8NPxpzmZ5IlJ9TEplsSZfJ/uzMNOEnTObKl4wAhxs51Nb58raH3Ouzwu14YHOpqYrBTEoT1yPA==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/ticker": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/loaders": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.4.tgz",
-      "integrity": "sha512-/dFznZnsivzq/MW7n/PPhMeznWFMMDYrac958OlxzSwrEAgtq6ZVLZbz7pCf9uhiifMnqwBGefphOFubj3Qorw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.11.tgz",
+      "integrity": "sha512-1HAeb/NFXyhNhZWAbVkngsTPBGpjZEPhQflBTrKycRaub7XDSZ8F0fwPltpKKVRWNDT+HBgU/zDNE2fpjzqfYg==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/utils": "5.3.4",
+        "@pixi/core": "5.3.11",
+        "@pixi/utils": "5.3.11",
         "resource-loader": "^3.0.1"
       }
     },
     "@pixi/math": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.4.tgz",
-      "integrity": "sha512-UQ2jhdlCHIvAVf8EcHB3QuR5GhB49VdTccWmer96RZCeGkcZsPSUk1ldO1GZnIctcf0Iuvmq74G02dYbtC7JxQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+      "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
       "dev": true
     },
     "@pixi/mesh": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.4.tgz",
-      "integrity": "sha512-y0Y52cwsqETc/35DMGVCzQmhPCrQ3ZhjWcW9JwQoHMy3PoNSN9QUqYjVjF2oEj5hxcJnGNo3GAXFZz2Uh/UReQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.11.tgz",
+      "integrity": "sha512-KWKKksEr0YuUX1uz1FmpIa/Y37b/0pvFUS+87LoyYq0mRtGbKsTY5i3lBPG/taHwN7a2DQAX3JZpw6yhGKoGpA==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/mesh-extras": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.4.tgz",
-      "integrity": "sha512-mjc3RlgLGYUv2FUKrVv/Dfaj2KW5qhX9c6Ev+yJ4lg/sMblet5gtYuyKsmJMS/K6B8V8+oMlTfX9ozFCzq1oJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.11.tgz",
+      "integrity": "sha512-1GTCMMUW1xv/72x26cxRysblBXW0wU77TNgqtSIMZ1M6JbleObChklWTvwi9MzQO2vQ3S6Hvcsa5m5EiM2hSPQ==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/mesh": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.4.tgz",
-      "integrity": "sha512-8ZAmzDK1fHXIzYFHFH72LUMRZerY1Pt71XI3UgsWExABS1aREe20oPLuVByLP94W7X/kTXz+zK+nt51O5MGKsA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.11.tgz",
+      "integrity": "sha512-uQUxatGTTD5zfQ0pWdjibVjT+xEEZJ/xZDZtm/GxC7HSHd4jgoJBcTXWVhbhzwpLPVTnD8+sMnRrGlhoKcpTpQ==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.4.tgz",
-      "integrity": "sha512-PY1Qe6CKYu+UNSRAFIfRyhRfkrpsTMwh9sI6iXVVi712bM3JkZIwDfDF31TA4nYX8z7H49w+KCWY4PejZ8l2WA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.11.tgz",
+      "integrity": "sha512-fWFVxWtMYcwJttrgDNmZ4CJrx316p8ToNliC2ILmJZW77me7I4GzJ57gSHQU1xFwdHoOYRC4fnlrZoK5qJ9lDw==",
       "dev": true,
       "requires": {
-        "@pixi/display": "5.3.4"
+        "@pixi/display": "5.3.11"
       }
     },
     "@pixi/mixin-get-global-position": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.4.tgz",
-      "integrity": "sha512-yv+huwUAOfyXDEHbQp6W5/3RjQpwG6AhpgMY4b3XBMtvrp9R/5Wgw/YC/nea9kZ3Gb2u4Aqeco8U+tPIRNjeIA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.11.tgz",
+      "integrity": "sha512-wrS9i+UUodLM5XL2N0Y+XSKiqLRdJV3ltFUWG6+jPT5yoP0HsKtx3sFAzX526RwIYwRzRusbc/quxHfRA4tvgg==",
       "dev": true,
       "requires": {
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4"
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11"
       }
     },
     "@pixi/particles": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.4.tgz",
-      "integrity": "sha512-sX0BGGbS7yCwlam1mC5awW2BjU7QFmZv82E8ON/r9aAZS6InT25zOpMdvy0ImIIqBvF0Z1Qz1IT6pKEBxqMo9Q==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.11.tgz",
+      "integrity": "sha512-+mkt/inWXtRrxQc07RZ29uNIDWV1oMsrRBVBIvHgpR92Kn8EjIDRgoSXNu0jiZ18gRKKCBhwsS4dCXGsZRQ/sA==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/polyfill": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.4.tgz",
-      "integrity": "sha512-bxk8bhrfQ9Y2rU/L0ss2gIeXwmMlOciw+B5yVUDVLqzjE4y8Fm2619L4qu9v51Z9a+8JbyVE5c1eT7HJgx0g0w==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.11.tgz",
+      "integrity": "sha512-yQOngcnn+2/L7n6L/g45hCnIDLWdnWmmcCY3UKJrOgbNX+JtLru1RR8AGLifkdsa0R5u48x584YQGqkTAChWVA==",
       "dev": true,
       "requires": {
         "es6-promise-polyfill": "^1.2.0",
@@ -1315,131 +1313,131 @@
       }
     },
     "@pixi/prepare": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.4.tgz",
-      "integrity": "sha512-MVMvNTrNYQidWXd4LSkgv+eqTzHtSViADA+Tvnemy9QMuWqbTfxFn4UMhrBjQIfG9+hwdIFS14pfFKt/BLHNrw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.11.tgz",
+      "integrity": "sha512-TvjGeg7xPKjv5NxbM5NXReno9yxUCw/N0HtDEtEFRVeBLN3u0Q/dZsXxL6gIvkHoS09NFW+7AwsYQLZrVbppjA==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/graphics": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/ticker": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/graphics": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/text": "5.3.11",
+        "@pixi/ticker": "5.3.11"
       }
     },
     "@pixi/runner": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.4.tgz",
-      "integrity": "sha512-iPWHVhv2js+NhDQNmePkHfic8SilBT7H/pzRjMqHqvafTdl8Y+4g+hdQDalZJNr3Ixl77QPAYlOKhegBujn2mQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+      "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
       "dev": true
     },
     "@pixi/settings": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.4.tgz",
-      "integrity": "sha512-Jqj1NLtYODCqK8ZKVccUBAaBDkn7SQ6b7N15FwxbiSgfbvwpynSKr6WQTxqMq29h42MKsic6BJcQrlGEbDNz5w==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+      "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
       "dev": true,
       "requires": {
         "ismobilejs": "^1.1.0"
       }
     },
     "@pixi/sprite": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.4.tgz",
-      "integrity": "sha512-vO+GMJWnumnVzc2R7jGcLlUeIXIek+SDqVQyPDPJ5T8sWTgFhanHCrgpKfplZIu08X/zvIZQxPfd332R0waeog==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+      "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/sprite-animated": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.4.tgz",
-      "integrity": "sha512-HaTelbvm2xekw9b9GdYbupM2RZ/muRZvstkmSqMZhiIViZekzKPa5WQJwnqZzVBjCg735j09G8aF4H2NpNqF9g==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.11.tgz",
+      "integrity": "sha512-xU1b6H8nJ1l05h7cBGw2DGo4QdLj7xootstZUx2BrTVX5ZENn5mjAGVD0uRpk8yt7Q6Bj7M+PS7ktzAgBW/hmQ==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/ticker": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/ticker": "5.3.11"
       }
     },
     "@pixi/sprite-tiling": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.4.tgz",
-      "integrity": "sha512-NMqpNuWEIic2n5EL/TrGmn1+bab4TwxcILnco4myvw9Sd/wLsaJx3XboegY7YCWCKhnl+Ax6cl8DMkk7OJkpJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.11.tgz",
+      "integrity": "sha512-KUiWsIumjrnp9QKGMe1BqtrV9Hxm91KoaiOlCBk/gw8753iKvuMmH+/Z0RnzeZylJ1sJsdonTWy/IaLi1jnd0g==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/spritesheet": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.4.tgz",
-      "integrity": "sha512-gfCqOMD2XJHw1bMXxXbuYPnBbCBUvbzMN7Pw2po7U5R6bsk7WEoG7Hp3HjAPyPQvg36v2Db6dcz0//ZNNqm+EQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.11.tgz",
+      "integrity": "sha512-Y9Wiwcz/YOuS1v73Ij9KWQakYBzZfldEy3H8T4GPLK+S19/sypntdkNtRZbmR2wWfhJ4axYEB2/Df86aOAU2qA==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/loaders": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/text": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.4.tgz",
-      "integrity": "sha512-kmdK1KLrWY8PHGIIXKVRQmik3gWquiYz6DB0jqabi3j0gVp6h+CVDje01N6Nl75ZCQ/PjaWafzQvURypfX73ng==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.11.tgz",
+      "integrity": "sha512-PmWvJv0wiKyyz3fahnxM19+m8IbF2vpDKIImqb5472WyxRGzKyVBW90xrADf5202tdKMk4b8hqvpof2XULr5PA==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/text-bitmap": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.4.tgz",
-      "integrity": "sha512-uNJOYvy3sn0S5Bp6H113ZAmaQm68ojCXSuOBJzIMEV2cUuYLngW+7DqKOsHMMhNmcONs/OBq57SRrzDcr8WYdw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.11.tgz",
+      "integrity": "sha512-Bjc/G4VHaPXc9HJsvyYOm5cNTHdqmX6AgzBAlCfltuMAlnveUgUPuX8D/MJHRRnoVSDHSmCBtnJgTc0y/nIeCw==",
       "dev": true,
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/loaders": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/mesh": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/text": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "@pixi/ticker": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.4.tgz",
-      "integrity": "sha512-PmCAstgyI6vLPXKZVFlo4Zornry21BwFiTOp1dBUW3sIMky9Wx2fajjyVHIridCY6yaazt6Xu37khZf5qRgASw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+      "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
       "dev": true,
       "requires": {
-        "@pixi/settings": "5.3.4"
+        "@pixi/settings": "5.3.11"
       }
     },
     "@pixi/utils": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.4.tgz",
-      "integrity": "sha512-HjUWFfAmPPKX0BSq20GWY//Vm+gC9O+wcn9sXMqOItCuf0DDFwxoBrUVaHNNnEVhM1Djpz/+YijCijmGdZeddA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+      "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/settings": "5.3.4",
+        "@pixi/constants": "5.3.11",
+        "@pixi/settings": "5.3.11",
         "earcut": "^2.1.5",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
@@ -1462,6 +1460,18 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@socket.io/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==",
+      "dev": true
+    },
+    "@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.14",
@@ -1503,12 +1513,6 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "@types/component-emitter": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
-      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==",
-      "dev": true
     },
     "@types/faker": {
       "version": "5.5.6",
@@ -1560,9 +1564,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.6.tgz",
-      "integrity": "sha512-SmgCQRzGPId4MZQKDj9Hqc6kSXFNWZFHpELkyK8AQhf8Zr6HKfCzFv9ZC1Fv3FyQttJZOlap3qYb12h61iZAIg==",
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
@@ -1605,9 +1609,9 @@
       "dev": true
     },
     "@types/simple-peer": {
-      "version": "9.11.1",
-      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.1.tgz",
-      "integrity": "sha512-Pzqbau/WlivSXdRC0He2Wz/ANj2wbi4gzJrtysZz93jvOyI2jo/ibMjUe6AvPllFl/UO6QXT/A0Rcp44bDQB5A==",
+      "version": "9.11.4",
+      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.4.tgz",
+      "integrity": "sha512-Elje14YvM47k+XEaoyRAeUSvZN7TOLWYL233QCckUaXjT4lRESHnYs0iOK2JoosO5DnCvWu/0Vpl9qnw4KCLWw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -2634,12 +2638,6 @@
           }
         }
       }
-    },
-    "base64-arraybuffer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
-      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -4027,26 +4025,26 @@
       }
     },
     "engine.io-client": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-5.1.2.tgz",
-      "integrity": "sha512-blRrgXIE0A/eurWXRzvfCLG7uUFJqfTGFsyJzXSK71srMMGJ2VraBLg8Mdw28uUxSpVicepBN9X7asqpD1mZcQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.0.3.tgz",
+      "integrity": "sha512-IH8ZhDIwiLv0d/wXVzmjfV9Y82hbJIDhCGSVUV8o1kcpDe2I6Y3bZA3ZbJy4Ls7k7IVmcy/qn4k9RKWFhUGf5w==",
       "dev": true,
       "requires": {
-        "base64-arraybuffer": "0.1.4",
-        "component-emitter": "~1.3.0",
+        "@socket.io/component-emitter": "~3.0.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~4.0.1",
+        "engine.io-parser": "~5.0.0",
         "has-cors": "1.1.0",
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
-        "ws": "~7.4.2",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0",
         "yeast": "0.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -4059,20 +4057,20 @@
           "dev": true
         },
         "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
           "dev": true
         }
       }
     },
     "engine.io-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
-      "integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
+      "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
       "dev": true,
       "requires": {
-        "base64-arraybuffer": "0.1.4"
+        "@socket.io/base64-arraybuffer": "~1.0.2"
       }
     },
     "enquirer": {
@@ -10357,9 +10355,9 @@
       "dev": true
     },
     "parse-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.3.tgz",
-      "integrity": "sha512-upMnGxNcm+45So85HoguwZTVZI9u11i36DdxJfGF2HYWS2eh3TIx7+/tTi7qrEq15qzGkVhsKjesau+kCk48pA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
+      "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
       "dev": true
     },
     "parse5": {
@@ -10506,45 +10504,45 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.4.tgz",
-      "integrity": "sha512-CrAaQQRw+iTA75IEu57CEk6stFs587iWE3HwQG0rZL2ESW2uJvdsF/ieeS/hFk35QmlEsPRqmH1sf7t7FGtsyw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.11.tgz",
+      "integrity": "sha512-/9td6IHDQqG0Po5lyQ5aKDzrnEVD1SvGourI4Nqp0mvNI0Cbm74tMHLjk1V5foqGPAS9pochENr6Y3ft/2cDiQ==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "5.3.4",
-        "@pixi/app": "5.3.4",
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/extract": "5.3.4",
-        "@pixi/filter-alpha": "5.3.4",
-        "@pixi/filter-blur": "5.3.4",
-        "@pixi/filter-color-matrix": "5.3.4",
-        "@pixi/filter-displacement": "5.3.4",
-        "@pixi/filter-fxaa": "5.3.4",
-        "@pixi/filter-noise": "5.3.4",
-        "@pixi/graphics": "5.3.4",
-        "@pixi/interaction": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/mesh-extras": "5.3.4",
-        "@pixi/mixin-cache-as-bitmap": "5.3.4",
-        "@pixi/mixin-get-child-by-name": "5.3.4",
-        "@pixi/mixin-get-global-position": "5.3.4",
-        "@pixi/particles": "5.3.4",
-        "@pixi/polyfill": "5.3.4",
-        "@pixi/prepare": "5.3.4",
-        "@pixi/runner": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/sprite-animated": "5.3.4",
-        "@pixi/sprite-tiling": "5.3.4",
-        "@pixi/spritesheet": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/text-bitmap": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/accessibility": "5.3.11",
+        "@pixi/app": "5.3.11",
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/extract": "5.3.11",
+        "@pixi/filter-alpha": "5.3.11",
+        "@pixi/filter-blur": "5.3.11",
+        "@pixi/filter-color-matrix": "5.3.11",
+        "@pixi/filter-displacement": "5.3.11",
+        "@pixi/filter-fxaa": "5.3.11",
+        "@pixi/filter-noise": "5.3.11",
+        "@pixi/graphics": "5.3.11",
+        "@pixi/interaction": "5.3.11",
+        "@pixi/loaders": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/mesh": "5.3.11",
+        "@pixi/mesh-extras": "5.3.11",
+        "@pixi/mixin-cache-as-bitmap": "5.3.11",
+        "@pixi/mixin-get-child-by-name": "5.3.11",
+        "@pixi/mixin-get-global-position": "5.3.11",
+        "@pixi/particles": "5.3.11",
+        "@pixi/polyfill": "5.3.11",
+        "@pixi/prepare": "5.3.11",
+        "@pixi/runner": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/sprite-animated": "5.3.11",
+        "@pixi/sprite-tiling": "5.3.11",
+        "@pixi/spritesheet": "5.3.11",
+        "@pixi/text": "5.3.11",
+        "@pixi/text-bitmap": "5.3.11",
+        "@pixi/ticker": "5.3.11",
+        "@pixi/utils": "5.3.11"
       }
     },
     "pkg-dir": {
@@ -12016,24 +12014,23 @@
       }
     },
     "socket.io-client": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.1.2.tgz",
-      "integrity": "sha512-RDpWJP4DQT1XeexmeDyDkm0vrFc0+bUsHDKiVGaNISJvJonhQQOMqV9Vwfg0ZpPJ27LCdan7iqTI92FRSOkFWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.3.2.tgz",
+      "integrity": "sha512-2B9LqSunN60yV8F7S84CCEEcgbYNfrn7ejIInZtLZ7ppWtiX8rGZAjvdCvbnC8bqo/9RlCNOUsORLyskxSFP1g==",
       "dev": true,
       "requires": {
-        "@types/component-emitter": "^1.2.10",
+        "@socket.io/component-emitter": "~3.0.0",
         "backo2": "~1.0.2",
-        "component-emitter": "~1.3.0",
-        "debug": "~4.3.1",
-        "engine.io-client": "~5.1.1",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.0.1",
         "parseuri": "0.0.6",
-        "socket.io-parser": "~4.0.4"
+        "socket.io-parser": "~4.1.1"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -12048,20 +12045,19 @@
       }
     },
     "socket.io-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
+      "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
       "dev": true,
       "requires": {
-        "@types/component-emitter": "^1.2.10",
-        "component-emitter": "~1.3.0",
+        "@socket.io/component-emitter": "~3.0.0",
         "debug": "~4.3.1"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -12636,9 +12632,9 @@
       "dev": true
     },
     "tinymce": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.1.tgz",
-      "integrity": "sha512-1zGXdZplWQafstlC7sri0ttCgMagsiXDc9N3I8JNrPOsWAeTfq4AAJWZoxsQBYn8gYcuPu/WzMKG5SoJjxI1VA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.1.tgz",
+      "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
       "dev": true
     },
     "tmp": {
@@ -12942,15 +12938,15 @@
       }
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
-      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
       "dev": true,
       "optional": true
     },
@@ -13476,6 +13472,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@league-of-foundry-developers/foundry-vtt-types": "^0.8.9-2",
+    "@league-of-foundry-developers/foundry-vtt-types": "^9.268.0",
     "@types/faker": "^5.5.6",
     "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
@@ -53,7 +53,7 @@
     "sass": "^1.32.8",
     "sass-lint": "^1.13.1",
     "ts-jest": "^26.5.6",
-    "typescript": "^4.4.2",
+    "typescript": "^4.6.3",
     "yargs": "^16.2.0"
   },
   "dependencies": {

--- a/src/module/actor/ABFActorSheet.ts
+++ b/src/module/actor/ABFActorSheet.ts
@@ -103,7 +103,7 @@ export default class ABFActorSheet extends ActorSheet {
 
     await this.updateItems(itemChanges);
 
-    return super._updateObject(event, actorChanges);
+    return super._updateObject(event, actorChanges) as Promise<ABFActor | undefined>;
   }
 
   activateListeners(html) {

--- a/src/module/dialogs/GenericDialog.ts
+++ b/src/module/dialogs/GenericDialog.ts
@@ -10,7 +10,7 @@ type GenericDialogData = {
   buttons: ButtonConfig[];
 };
 
-export class GenericDialog extends FormApplication<FormApplication.Options, GenericDialogData> {
+export class GenericDialog extends FormApplication<FormApplicationOptions, GenericDialogData> {
   private data: GenericDialogData;
 
   constructor(data: GenericDialogData) {

--- a/src/module/dialogs/combat/CombatAttackDialog.ts
+++ b/src/module/dialogs/combat/CombatAttackDialog.ts
@@ -149,7 +149,7 @@ const getInitialData = (
   };
 };
 
-export class CombatAttackDialog extends FormApplication<FormApplication.Options, UserCombatAttackDialogData> {
+export class CombatAttackDialog extends FormApplication<FormApplicationOptions, UserCombatAttackDialogData> {
   private data: UserCombatAttackDialogData;
 
   constructor(

--- a/src/module/dialogs/combat/CombatDefenseDialog.ts
+++ b/src/module/dialogs/combat/CombatDefenseDialog.ts
@@ -151,7 +151,7 @@ const getInitialData = (
   };
 };
 
-export class CombatDefenseDialog extends FormApplication<FormApplication.Options, UserCombatDefenseDialogData> {
+export class CombatDefenseDialog extends FormApplication<FormApplicationOptions, UserCombatDefenseDialogData> {
   private data: UserCombatDefenseDialogData;
 
   constructor(

--- a/src/module/dialogs/combat/GMCombatDialog.ts
+++ b/src/module/dialogs/combat/GMCombatDialog.ts
@@ -78,7 +78,7 @@ const getInitialData = (
   };
 };
 
-export class GMCombatDialog extends FormApplication<FormApplication.Options, GMCombatDialogData> {
+export class GMCombatDialog extends FormApplication<FormApplicationOptions, GMCombatDialogData> {
   private data: GMCombatDialogData;
 
   constructor(

--- a/src/module/items/ABFItemSheet.ts
+++ b/src/module/items/ABFItemSheet.ts
@@ -11,7 +11,7 @@ export default class ABFItemSheet extends ItemSheet {
     });
   }
 
-  constructor(object: ABFItem, options?: Partial<DocumentSheet.Options>) {
+  constructor(object: ABFItem, options?: Partial<DocumentSheetOptions>) {
     super(object, options);
 
     this.position.width = this.getWidthFromType();

--- a/src/module/macros/functions/damageCalculatorMacro.ts
+++ b/src/module/macros/functions/damageCalculatorMacro.ts
@@ -65,11 +65,23 @@ export const damageCalculatorMacro = async () => {
   }
 
   const typedGame = game as Game;
-  ChatMessage.create({
-    content: final,
-    whisper: typedGame.collections
-      ?.get('User')
-      ?.filter(u => u.isGM)
-      ?.map(u => u.id)
-  });
+
+  const user = typedGame.collections?.get('User') as User[] | undefined;
+
+  if (user !== undefined) {
+    const isGM = u => u.isGM;
+    const hasId = u => u.id !== null;
+
+    const gmIds = user
+      .filter(isGM)
+      .filter(hasId)
+      .map(u => u.id!);
+
+    if (gmIds.length > 0) {
+      ChatMessage.create({
+        content: final,
+        whisper: gmIds
+      });
+    }
+  }
 };

--- a/src/module/types/Items.ts
+++ b/src/module/types/Items.ts
@@ -91,7 +91,7 @@ export type ABFItemConfig<D, C> = {
      * Function that allows to create new items in the contextual menu
      * @param actor
      */
-    buildExtraOptionsInContextMenu?: (actor: ABFActor) => ContextMenu.Item[];
+    buildExtraOptionsInContextMenu?: (actor: ABFActor) => ContextMenuEntry[];
   };
 
   /**

--- a/src/scss/actor/parts/main.scss
+++ b/src/scss/actor/parts/main.scss
@@ -1,5 +1,46 @@
 @import 'src/scss/variable';
 
+.abf-tabs {
+  &.secondary-tab {
+    margin-top: 0;
+    height: 1.2rem;
+    line-height: 1.2rem;
+  }
+
+  flex: 0 0 2rem;
+  line-height: 2rem;
+
+  height: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+
+  border-top: 1px solid $red;
+  border-bottom: 1px solid $red;
+
+  .item {
+    background: transparent;
+    border-radius: $border-radius;
+    color: $black;
+    font-weight: 600;
+
+    display: flex;
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .active {
+    text-shadow: none;
+    background-color: $red;
+    color: $white;
+    font-weight: 600;
+  }
+}
+
 .actor-sheet {
   display: flex;
   flex-direction: column;
@@ -8,53 +49,14 @@
   .mystic-tabs,
   .psychic-tabs,
   .general-tabs {
-    &.secondary-tab {
-      margin-top: 0;
-      height: 1.2rem;
-      line-height: 1.2rem;
-    }
+    .item[data-tab='settings'] {
+      flex: 0.5;
 
-    flex: 0 0 2rem;
-    line-height: 2rem;
-
-    height: 2rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    margin-top: 0.75rem;
-    margin-bottom: 0.75rem;
-
-    border-top: 1px solid $red;
-    border-bottom: 1px solid $red;
-
-    .item {
-      background: transparent;
-      border-radius: $border-radius;
-      color: $black;
-      font-weight: 600;
-
-      display: flex;
-      flex: 1;
-      justify-content: center;
-      align-items: center;
-
-      &[data-tab='settings'] {
-        flex: 0.5;
-
-        img {
-          width: 1.5rem;
-          height: 1.5rem;
-          border-radius: 50%;
-        }
+      img {
+        width: 1.5rem;
+        height: 1.5rem;
+        border-radius: 50%;
       }
-    }
-
-    .active {
-      text-shadow: none;
-      background-color: $red;
-      color: $white;
-      font-weight: 600;
     }
   }
 }

--- a/src/scss/actor/parts/main.scss
+++ b/src/scss/actor/parts/main.scss
@@ -11,13 +11,16 @@
     &.secondary-tab {
       margin-top: 0;
       height: 1.2rem;
+      line-height: 1.2rem;
     }
+
+    flex: 0 0 2rem;
+    line-height: 2rem;
 
     height: 2rem;
     display: flex;
     justify-content: center;
     align-items: center;
-    line-height: inherit;
 
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
@@ -32,6 +35,7 @@
       font-weight: 600;
 
       display: flex;
+      flex: 1;
       justify-content: center;
       align-items: center;
 

--- a/src/system.json
+++ b/src/system.json
@@ -14,28 +14,28 @@
       "label": "(ES) Armas",
       "system": "animabf",
       "path": "./packs/weapons_es.db",
-      "entity": "Item"
+      "type": "Item"
     },
     {
       "name": "armors",
       "label": "(ES) Armaduras",
       "system": "animabf",
       "path": "./packs/armors_es.db",
-      "entity": "Item"
+      "type": "Item"
     },
     {
       "name": "magic",
       "label": "(ES) Magia",
       "system": "animabf",
       "path": "./packs/magic_es.db",
-      "entity": "Item"
+      "type": "Item"
     },
     {
       "name": "psychic",
       "label": "(ES) Mentalismo",
       "system": "animabf",
       "path": "./packs/psychic_powers_es.db",
-      "entity": "Item"
+      "type": "Item"
     }
   ],
   "languages": [

--- a/src/templates/actor/actor-sheet.hbs
+++ b/src/templates/actor/actor-sheet.hbs
@@ -4,7 +4,7 @@
   </header>
 
   {{!-- Character Sheet Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
+  <nav class="abf-tabs sheet-tabs tabs" data-group="primary">
     <a class="item" data-tab="main">{{localize "anima.ui.tabs.main"}}</a>
     <a class="item" data-tab="secondaries">{{localize "anima.ui.tabs.secondaries"}}</a>
     <a class="item" data-tab="combat">{{localize "anima.ui.tabs.combat"}}</a>

--- a/src/templates/actor/parts/general/general.hbs
+++ b/src/templates/actor/parts/general/general.hbs
@@ -1,5 +1,5 @@
 <div class='general'>
-  <nav class="general-tabs tabs secondary-tab" data-group="secondary">
+  <nav class="abf-tabs general-tabs tabs secondary-tab" data-group="secondary">
     <a class="item active" data-tab="general-first">{{localize "anima.ui.general.tabs.first"}}</a>
     <a class="item" data-tab="general-second">{{localize "anima.ui.general.tabs.second"}}</a>
     <a class="item" data-tab="general-third">{{localize "anima.ui.general.tabs.third"}}</a>

--- a/src/templates/actor/parts/mystic/mystic.hbs
+++ b/src/templates/actor/parts/mystic/mystic.hbs
@@ -1,5 +1,5 @@
 <div class='mystic'>
-  <nav class="mystic-tabs tabs secondary-tab" data-group="secondary">
+  <nav class="abf-tabs mystic-tabs tabs secondary-tab" data-group="secondary">
     <a class="item active" data-tab="mystic-main">{{localize "anima.ui.mystic.tabs.main"}}</a>
     <a class="item" data-tab="mystic-spells">{{localize "anima.ui.mystic.tabs.secondaries"}}</a>
   </nav>

--- a/src/templates/actor/parts/psychic/psychic.hbs
+++ b/src/templates/actor/parts/psychic/psychic.hbs
@@ -1,5 +1,5 @@
 <div class='psychic'>
-  <nav class="psychic-tabs tabs secondary-tab" data-group="secondary">
+  <nav class="abf-tabs psychic-tabs tabs secondary-tab" data-group="secondary">
     <a class="item active" data-tab="psychic-main">{{localize "anima.ui.psychic.tabs.main"}}</a>
     <a class="item" data-tab="psychic-powers">{{localize "anima.ui.psychic.tabs.secondaries"}}</a>
   </nav>

--- a/src/templates/dialog/combat/combat-attack/combat-attack-dialog.hbs
+++ b/src/templates/dialog/combat/combat-attack/combat-attack-dialog.hbs
@@ -10,7 +10,7 @@
       class="attack-values"
     }}
       {{#if this.allowed}}
-        <nav class="sheet-tabs tabs" data-group="primary">
+        <nav class="abf-tabs sheet-tabs tabs" data-group="primary">
           <a class="item" data-tab="combat">{{localize "anima.ui.tabs.combat"}}</a>
           {{#if (is 'gt' this.attacker.actor.data.data.mystic.spells.length 0)}}<a class="item" data-tab="mystic">{{localize "anima.ui.tabs.mystic"}}</a>{{/if}}
           {{#if (is 'gt' this.attacker.actor.data.data.psychic.psychicPowers.length 0)}}<a class="item" data-tab="psychic">{{localize "anima.ui.tabs.psychic"}}</a>{{/if}}

--- a/src/templates/dialog/combat/combat-defense/combat-defense-dialog.hbs
+++ b/src/templates/dialog/combat/combat-defense/combat-defense-dialog.hbs
@@ -9,7 +9,7 @@
     {{#> "systems/animabf/templates/common/ui/group-body.hbs"
       class="defense-values"
     }}
-      <nav class="sheet-tabs tabs" data-group="primary">
+      <nav class="abf-tabs sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="combat">{{localize "anima.ui.tabs.combat"}}</a>
         {{#if (is 'gt' this.defender.actor.data.data.mystic.spells.length 0)}}<a class="item" data-tab="mystic">{{localize "anima.ui.tabs.mystic"}}</a>{{/if}}
         {{#if (is 'gt' this.defender.actor.data.data.psychic.psychicPowers.length 0)}}<a class="item" data-tab="psychic">{{localize "anima.ui.tabs.psychic"}}</a>{{/if}}


### PR DESCRIPTION
Finally, I found some time to migrate the types of Foundry VTT 9. Here it is.

Some change notes:

- For some reason, Foundry doesn't maintain the support of the tabs style, so I have to re-write some style code, not a big deal.
- The damage calculator was the "big" change. I said "big" because was just a few lines of code.

I tested in my current campaign world and everything works fine.