### PR TITLE
[Changes] Hide attacker and defender internal data

### DIFF
--- a/src/module/dialogs/combat/GMCombatDialog.ts
+++ b/src/module/dialogs/combat/GMCombatDialog.ts
@@ -160,8 +160,14 @@ export class GMCombatDialog extends FormApplication<FormApplicationOptions, GMCo
 
     html.find('.show-results').click(async () => {
       const data: Record<string, any> = {
-        attacker: this.attackerActor,
-        defender: this.defenderActor,
+        attacker: {
+          name: this.attackerToken.name,
+          img: this.attackerToken.data.img
+        },
+        defender: {
+          name: this.defenderToken.name,
+          img: this.defenderToken.data.img
+        },
         result: this.data.calculations?.difference,
         canCounter: this.data.calculations?.canCounter
       };
@@ -226,7 +232,7 @@ export class GMCombatDialog extends FormApplication<FormApplicationOptions, GMCo
   }
 
   updateDefenderData(result: UserCombatDefenseResult) {
-    result.values.total = Math.max(0, result.values.total)
+    result.values.total = Math.max(0, result.values.total);
     this.data.defender.result = result;
 
     if (result.type === 'mystic') {


### PR DESCRIPTION
When combat results were sent to the chat, enemies' info like name and image was shown instead of the token that actually is doing the attack.

In this PR token name and image is used instead.