### PR TITLE
Feature/pantalla acumulacion

### DIFF
--- a/src/module/dialogs/combat/CombatDefenseDialog.ts
+++ b/src/module/dialogs/combat/CombatDefenseDialog.ts
@@ -21,6 +21,7 @@ export type UserCombatDefenseDialogData = {
   ui: {
     isGM: boolean;
     hasFatiguePoints: boolean;
+    activeTab: string;
   };
   attacker: {
     actor: ABFActor;
@@ -129,10 +130,13 @@ const getInitialData = (
   const attackerActor = attacker.token.actor!;
   const defenderActor = defender.actor!;
 
+  const activeTab = (defenderActor.data.data.general.settings.defenseType.value === 'resistance') ? 'damageResistance' : 'combat'
+
   return {
     ui: {
       isGM,
-      hasFatiguePoints: defenderActor.data.data.characteristics.secondaries.fatigue.value > 0
+      hasFatiguePoints: defenderActor.data.data.characteristics.secondaries.fatigue.value > 0,
+      activeTab: activeTab
     },
     attacker: {
       token: attacker.token,
@@ -190,7 +194,10 @@ export class CombatDefenseDialog extends FormApplication<FormApplicationOptions,
     super(getInitialData(attacker, defender));
 
     this.data = getInitialData(attacker, defender);
-
+    this._tabs[0].callback = (event: MouseEvent | null, tabs: Tabs, tabName: string) => {
+      this.data.ui.activeTab = tabName;
+      this.render(true);
+    }
     const weapons = this.defenderActor.data.data.combat.weapons as WeaponDataSource[];
 
     if (weapons.length > 0) {

--- a/src/templates/dialog/combat/combat-defense/combat-defense-dialog.hbs
+++ b/src/templates/dialog/combat/combat-defense/combat-defense-dialog.hbs
@@ -9,37 +9,39 @@
     {{#> "systems/animabf/templates/common/ui/group-body.hbs"
       class="defense-values"
     }}
-    <nav class="abf-tabs sheet-tabs tabs" data-group="primary">
-        {{#if (is 'eq' this.defender.actor.data.data.general.settings.defenseType.value 'resistance')}}<a class="item" data-tab="damageResistance">{{localize "anima.ui.tabs.damageResistance"}}</a>
-        {{else}}<a class="item" data-tab="combat">{{localize "anima.ui.tabs.combat"}}</a>{{/if}}
-        {{#if (is 'gt' this.defender.actor.data.data.mystic.spells.length 0)}}<a class="item" data-tab="mystic">{{localize "anima.ui.tabs.mystic"}}</a>{{/if}}
-        {{#if (is 'gt' this.defender.actor.data.data.psychic.psychicPowers.length 0)}}<a class="item" data-tab="psychic">{{localize "anima.ui.tabs.psychic"}}</a>{{/if}}
-    </nav>
-
-      <div class='columns'>
-        <div>
-          {{>
-              "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-              title=(localize 'macros.combat.dialog.noRoll.title')
-              disabled=this.defenseSent
-              inputType="checkbox"
-              inputName="defender.withoutRoll"
-              inputValue=(is 'eq' this.defender.withoutRoll true)
-          }}
-        </div>
-        <div>
-          {{#if this.ui.isGM}}
+      <nav class="abf-tabs sheet-tabs tabs" data-group="primary">
+          {{#if (is 'eq' this.defender.actor.data.data.general.settings.defenseType.value 'resistance')}}<a class="item" data-tab="damageResistance">{{localize "anima.ui.tabs.damageResistance"}}</a>
+          {{else}}<a class="item" data-tab="combat">{{localize "anima.ui.tabs.combat"}}</a>{{/if}}
+          {{#if (is 'gt' this.defender.actor.data.data.mystic.spells.length 0)}}<a class="item" data-tab="mystic">{{localize "anima.ui.tabs.mystic"}}</a>{{/if}}
+          {{#if (is 'gt' this.defender.actor.data.data.psychic.psychicPowers.length 0)}}<a class="item" data-tab="psychic">{{localize "anima.ui.tabs.psychic"}}</a>{{/if}}
+      </nav>
+      {{log  this}}
+      {{#if (is 'neq' this.ui.activeTab 'damageResistance')}}
+        <div class='columns'>
+          <div>
             {{>
-            "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-              title=(localize 'macros.combat.dialog.showRoll.title')
-              disabled=this.defenseSent
-              inputType="checkbox"
-              inputName="defender.showRoll"
-              inputValue=(is 'eq' this.defender.showRoll true)
+                "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
+                title=(localize 'macros.combat.dialog.noRoll.title')
+                disabled=this.defenseSent
+                inputType="checkbox"
+                inputName="defender.withoutRoll"
+                inputValue=(is 'eq' this.defender.withoutRoll true)
             }}
-          {{/if}}
+          </div>
+          <div>
+            {{#if this.ui.isGM}}
+              {{>
+              "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
+                title=(localize 'macros.combat.dialog.showRoll.title')
+                disabled=this.defenseSent
+                inputType="checkbox"
+                inputName="defender.showRoll"
+                inputValue=(is 'eq' this.defender.showRoll true)
+              }}
+            {{/if}}
+          </div>
         </div>
-      </div>
+      {{/if}}
 
       {{#if (and (is "neq" this.attacker.critic "-") this.attacker.critic)}}
         {{>

--- a/src/templates/dialog/combat/combat-defense/parts/damage-resistance.hbs
+++ b/src/templates/dialog/combat/combat-defense/parts/damage-resistance.hbs
@@ -1,4 +1,4 @@
-<div class='defense-buttons'>
+<div class='columns'>
   {{>
     "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
       title=(localize 'macros.combat.dialog.surprised.title')
@@ -9,7 +9,7 @@
 </div>
 
 {{#if this.defenseSent}}
-  <div class='columns'>
+  <div class='defense-buttons'>
     {{>'systems/animabf/templates/common/ui/loading-indicator.hbs' class="big"}}
     <p class='label'>
       {{localize 'macros.combat.dialog.defenseSent.title'}}

--- a/src/templates/dialog/combat/gm-combat-dialog.hbs
+++ b/src/templates/dialog/combat/gm-combat-dialog.hbs
@@ -406,6 +406,13 @@
                     inputValue=this.defender.result.values.at
                   }}
                 {{/if}}
+                {{>
+                "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
+                  title=(localize 'macros.combat.dialog.surprised.title')
+                  inputType="checkbox"
+                  inputName="defender.result.values.surprised"
+                  inputValue=(is 'eq' this.defender.result.values.surprised true)
+                }}
               {{/if}}
 
               {{#if (is "eq" this.defender.result.type 'mystic')}}


### PR DESCRIPTION
Dos mejoras:
- Mostrar un check editable en la pantalla de resultado de defensa de un ser de acumulación para modificar si aplica sorprendido.
- Que los campos "sin tirada" y "Mostrar tirada" nunca aparezcan en la pestaña de defensa de Acumulación (puesto que no hay tirada)

![image](https://user-images.githubusercontent.com/38110017/169710321-57e6fb15-86ac-4b41-af00-c2368b927b17.png)
![image](https://user-images.githubusercontent.com/38110017/169710323-48101456-f4de-44d5-b264-1e2f2c966ce7.png)
