### PR TITLE
Fix combined armor

### DIFF
--- a/src/module/actor/utils/prepareActor/calculations/actor/mutateTotalArmor.ts
+++ b/src/module/actor/utils/prepareActor/calculations/actor/mutateTotalArmor.ts
@@ -4,11 +4,11 @@ import { ArmorDataSource, ArmorLocation } from '../../../../../types/combat/Armo
 const calculateTA = (tas: number[]): number => {
   if (tas.length === 0) return 0;
 
-  const orderedTas = [...tas].sort().reverse();
+  const orderedTas = new Int8Array([...tas]).sort().reverse();
 
-  const maxTa = orderedTas.shift();
+  const maxTa = orderedTas[0];
 
-  const sumOtherTas = orderedTas.reduce((prev, curr) => prev + curr, 0);
+  const sumOtherTas = orderedTas.slice(1).reduce((prev, curr) => prev + curr, 0);
 
   return maxTa! + Math.floor(sumOtherTas / 2);
 };


### PR DESCRIPTION
Fixes #148.

The problem was caused because of `.sort()` method of arrays not ordering numbers as numbers but _alphabetically_ which caused 12 to be _smaller_ than 4 since 1 goes before 4. Using typed arrays solved the issue since `Int8Array` (and all the int arrays) does sort integers correctly.