### PR TITLE
fix - mutateMovementType order

### DIFF
--- a/src/module/actor/utils/prepareActor/prepareActor.js
+++ b/src/module/actor/utils/prepareActor/prepareActor.js
@@ -20,7 +20,6 @@ import { mutateRegenerationType } from './calculations/actor/general/mutateRegen
 // Be careful with order of this functions, some derived data functions could be dependent of another
 const DERIVED_DATA_FUNCTIONS = [
   mutatePrimaryModifiers,
-  mutateMovementType,
   mutateRegenerationType,
   mutateAllActionsModifier,
   mutateCombatData,
@@ -29,6 +28,7 @@ const DERIVED_DATA_FUNCTIONS = [
   mutateNaturalPenalty,
   mutatePhysicalModifier,
   mutatePerceptionPenalty,
+  mutateMovementType,
   mutateSecondariesData,
   mutateAmmoData,
   mutateWeaponsData,


### PR DESCRIPTION
El problema con el cálculo del penalizador de movimiento por armadura, es que primero se está calculando el movimiento antes de haber calculado la armadura.
En este fix solo se cambia el orden de los mutateData para que funcione correctamente.