### PR TITLE
Migrations/new combat automation

### DIFF
--- a/src/module/actor/ABFActor.ts
+++ b/src/module/actor/ABFActor.ts
@@ -53,7 +53,7 @@ export class ABFActor extends Actor {
 
   /**
    * Updates the value of the 'fatigue' secondary characteristic of an ABFActor object.
-   * 
+   *
    * @param {number} fatigueUsed - The amount of fatigue to be subtracted from the current value.
    * @returns {void}
    */
@@ -72,15 +72,15 @@ export class ABFActor extends Actor {
 
   /**
    * Rolls an ability check for the ABFActor class.
-   * 
+   *
    * @param {string} ability - The name of the ability to roll.
    * @param {boolean} sendToChat - Whether to send the roll result to the chat. Default is true.
    * @returns {Promise<number>} - The total result of the dice roll.
-   * 
+   *
    * @example
    * const actor = new ABFActor(data, context);
    * await actor.rollAbility('agility', true);
-   * 
+   *
    * This code creates a new instance of the ABFActor class and calls the `rollAbility` method with the ability name 'agility' and the `sendToChat` parameter set to true. The method will calculate the ability value, prompt the user for a modifier, roll the dice, and display the result in the chat.
    */
   async rollAbility(ability: string, sendToChat = true) {
@@ -115,7 +115,7 @@ export class ABFActor extends Actor {
 
   /**
    * Creates a new supernatural shield item for the ABFActor class and execute a macro using the shield's name.
-   * 
+   *
    * @param {string} type - The type of the supernatural shield ('psychic' or 'mystic').
    * @param {any} power - The power object containing information about the psychic power. Only needed if type = 'psychic'.
    * @param {number} psychicDifficulty - The difficulty level of the psychic power. Only needed if type = 'psychic'.
@@ -195,14 +195,14 @@ export class ABFActor extends Actor {
 
   /**
    * Deletes a supernatural shield item from the actor's inventory and exucute a macro passing argument 'newShield: false, shieldId: supShieldId' to stop the corresponding the animation.
-   * 
+   *
    * @param supShieldId - The ID of the supernatural shield item to be deleted.
-   * @returns {void} 
+   * @returns {void}
    */
   async deleteSupernaturalShield(supShieldId: string) {
     const supShield = this.getItem(supShieldId);
     if (supShield) {
-      this.deleteItem(supShieldId)
+      this.deleteItem(supShieldId);
       let args = {
         thisActor: this,
         newShield: false,
@@ -215,12 +215,12 @@ export class ABFActor extends Actor {
   /**
    * Applies damage to a supernatural shield.
    * If the damage reduces the shield's points to zero or below, the shield is deleted and the remaining damage is recalculated and applied to the actor.
-   * 
+   *
    * @param {string} supShieldId - The ID of the supernatural shield to apply damage to.
    * @param {number} damage - The amount of damage to apply to the shield.
    * @param {boolean} [dobleDamage] - Whether to apply double damage or not. Default is `false`.
    * @param {object} [newCombatResult] - Additional combat result data used to calculate damage to the actor if the shield breaks.
-   * 
+   *
    * @returns {void}
    */
   async applyDamageSupernaturalShield(
@@ -236,7 +236,7 @@ export class ABFActor extends Actor {
       this.updateItem({
         id: supShieldId,
         system: { shieldPoints: newShieldPoints }
-      })
+      });
     } else {
       this.deleteSupernaturalShield(supShieldId);
       // If shield breaks, apply damage to actor
@@ -262,16 +262,26 @@ export class ABFActor extends Actor {
    * Evaluates the psychic fatigue caused by using a power in the game.
    * It checks if the actor has immunity to fatigue and calculates the fatigue value based on the power's effects and the psychic difficulty.
    * If the actor is not immune to fatigue, it applies the fatigue value to the actor's characteristics.
-   * 
+   *
    * @param {object} power - The power for which the psychic fatigue is being evaluated.
    * @param {number} psychicDifficulty - The difficulty level of the psychic power.
    * @param {boolean} eliminateFatigue - Whether to apply the fatigue value or not to the actor's characteristics.
    * @param {boolean} sendToChat - Whether to send a chat message or not. Default is `true`.
-   * 
+   *
    * @returns {number} The calculated psychic fatigue value.
    */
-  async evaluatePsychicFatigue(power: any, psychicDifficulty: number, eliminateFatigue: boolean, sendToChat = true) {
-    const { psychic: { psychicSettings: { fatigueResistance }, psychicPoints } } = this.system
+  async evaluatePsychicFatigue(
+    power: any,
+    psychicDifficulty: number,
+    eliminateFatigue: boolean,
+    sendToChat = true
+  ) {
+    const {
+      psychic: {
+        psychicSettings: { fatigueResistance },
+        psychicPoints
+      }
+    } = this.system;
     const psychicFatigue = {
       value: psychicFatigueCheck(power?.system.effects[psychicDifficulty].value),
       inmune: fatigueResistance || eliminateFatigue
@@ -292,10 +302,12 @@ export class ABFActor extends Actor {
         this.update({
           system: {
             psychic: {
-              psychicPoints: { value: Math.max(psychicPoints.value - psychicFatigue.value, 0) }
+              psychicPoints: {
+                value: Math.max(psychicPoints.value - psychicFatigue.value, 0)
+              }
             }
           }
-        })
+        });
       }
     }
     if (eliminateFatigue) {
@@ -305,7 +317,7 @@ export class ABFActor extends Actor {
             psychicPoints: { value: psychicPoints.value - 1 }
           }
         }
-      })
+      });
     }
 
     return psychicFatigue.value;
@@ -315,12 +327,14 @@ export class ABFActor extends Actor {
    * Performs maintenance on psychic shields by checking if they are overmaintained or need to be damaged.
    * If a psychic shield is overmaintained, it is either unset or damaged based on the `revert` parameter.
    * Its executed in every next turn in ABFCombat, if the combat goes to a previous turn the 'revert' parameter is set to true.
-   * 
+   *
    * @param revert - A flag indicating whether to revert the maintenance or not.
    * @returns {void}
    */
   async psychicShieldsMaintenance(revert: boolean) {
-    const psychicShields = this.system.combat.supernaturalShields.filter(s => s.system.type === 'psychic');
+    const psychicShields = this.system.combat.supernaturalShields.filter(
+      s => s.system.type === 'psychic'
+    );
 
     for (const psychicShield of psychicShields) {
       const psychic = psychicShield.getFlag('animabf', 'psychic');
@@ -341,7 +355,7 @@ export class ABFActor extends Actor {
 
   /**
    * Updates the defenses counter for an actor based on the value of the `keepAccumulating` parameter.
-   * 
+   *
    * @param {boolean} keepAccumulating - A flag indicating whether to continue accumulating defenses or not.
    * @returns {void}
    */
@@ -363,12 +377,12 @@ export class ABFActor extends Actor {
 
   /**
    * Resets the accumulated defenses counter for an ABFActor object.
-   * 
+   *
    * @example
    * const actor = new ABFActor(data, context);
    * actor.resetDefensesCounter();
-   * 
-   * @returns {void} 
+   *
+   * @returns {void}
    */
   resetDefensesCounter() {
     const defensesCounter = this.getFlag('animabf', 'defensesCounter');
@@ -384,20 +398,34 @@ export class ABFActor extends Actor {
 
   /**
    * Determines if a mystic character can cast a specific spell at a specific grade.
-   * 
-   * @param spell - The spell object that contains information about the spell, including the zeon cost for each grade.
+   *
+   * @param spell - The spell object that contains information about the spell, including the
+   * zeon cost for each grade.
    * @param spellGrade - The grade of the spell that the character wants to cast.
-   * @param casted - An object that indicates whether the spell has been casted before, either as a prepared spell or an innate spell. Default is { prepared: false, innate: false }.
-   * @param override - A flag that indicates whether to override the normal casting rules and allow the spell to be casted regardless of zeon points or previous casting. Default is false.
-   * @returns {SpellCasting} - An object that contains information about the zeon points, whether the spell can be cast (prepared or innate), if the spell has been casted, and whether the casting rules should be overridden.
+   * @param casted - An object that indicates whether the spell has been casted before,
+   * either as a prepared spell or an innate spell.
+   * Default is { prepared: false, innate: false }.
+   * @param override - A flag that indicates whether to override the normal casting rules and
+   * allow the spell to be casted regardless of zeon points or previous casting.
+   * Default is false.
+   * @returns {SpellCasting} - An object that contains information about the zeon points,
+   * whether the spell can be cast (prepared or innate), if the spell has been casted, and
+   * whether the casting rules should be overridden.
    */
-  mysticCanCastEvaluate(spell: any, spellGrade: string, casted = { prepared: false, innate: false }, override = false) {
+  mysticCanCastEvaluate(
+    spell: any,
+    spellGrade: string,
+    casted = { prepared: false, innate: false },
+    override = false
+  ) {
     const spellCasting = SpellCasting;
-    spellCasting.casted = casted
-    spellCasting.override = override
+    spellCasting.casted = casted;
+    spellCasting.override = override;
     spellCasting.zeon.accumulated = this.system.mystic.zeon.accumulated ?? 0;
 
-    if (override) { return spellCasting };
+    if (override) {
+      return spellCasting;
+    }
 
     spellCasting.zeon.cost = spell?.system.grades[spellGrade].zeon.value;
     spellCasting.canCast.prepared =
@@ -423,9 +451,12 @@ export class ABFActor extends Actor {
   }
 
   /**
-   * Evaluates the spell casting conditions and returns a boolean value indicating whether the spell can be cast or not.
-   * 
-   * @param {SpellCasting} spellCasting - - An object that contains information about the zeon points, whether the spell can be cast (prepared or innate), if the spell has been casted, and whether the casting rules should be overridden.
+   * Evaluates the spell casting conditions and returns a boolean value indicating whether the
+   * spell can be cast or not.
+   *
+   * @param {SpellCasting} spellCasting - - An object that contains information about the zeon
+   * points, whether the spell can be cast (prepared or innate), if the spell has been casted,
+   * and whether the casting rules should be overridden.
    * @returns {boolean} - A boolean value indicating whether the spell can be cast or not.
    */
   evaluateCast(spellCasting: SpellCasting) {
@@ -435,17 +466,13 @@ export class ABFActor extends Actor {
       return false;
     }
     if (canCast.innate && casted.innate && canCast.prepared && casted.prepared) {
-      ui.notifications.warn(
-        i18n.localize('dialogs.spellCasting.warning.mustChoose')
-      );
+      ui.notifications.warn(i18n.localize('dialogs.spellCasting.warning.mustChoose'));
       return true;
     }
     if (canCast.innate && casted.innate) {
       return;
     } else if (!canCast.innate && casted.innate) {
-      ui.notifications.warn(
-        i18n.localize('dialogs.spellCasting.warning.innateMagic')
-      );
+      ui.notifications.warn(i18n.localize('dialogs.spellCasting.warning.innateMagic'));
       return true;
     } else if (canCast.prepared && casted.prepared) {
       return false;
@@ -459,15 +486,15 @@ export class ABFActor extends Actor {
       );
       return true;
     } else return false;
-  };
+  }
 
   /**
    * Handles the casting of mystic spells by an actor in the ABFActor class.
-   * 
+   *
    * @param {SpellCasting} spellCasting - An object that contains information about the zeon points, whether the spell can be cast (prepared or innate), if the spell has been casted, and whether the casting rules should be overridden.
    * @param spellName - The name of the spell being casted.
    * @param spellGrade - The grade of the spell being casted.
-   * 
+   *
    * @returns {void}
    */
   mysticCast(spellCasting: SpellCasting, spellName: string, spellGrade: string) {
@@ -487,7 +514,7 @@ export class ABFActor extends Actor {
 
   /**
    * Updates the accumulated zeon value of a mystic character by subtracting the zeon cost of a spell.
-   * 
+   *
    * @param {number} zeonCost - The amount of zeon to be consumed.
    * @returns {void}
    */
@@ -506,7 +533,7 @@ export class ABFActor extends Actor {
   /**
    * Consumes or restores the amount of maintained Zeon for a Mystic character.
    * Used in every turn change in ABFCombat.
-   * 
+   *
    * @param {boolean} revert - A flag indicating whether to consume or restore the maintained Zeon. If `true`, the maintained Zeon will be restored to the character's total Zeon value. If `false`, the maintained Zeon will be consumed from the character's total Zeon value.
    * @returns A promise that resolves when the update is complete.
    */
@@ -525,10 +552,9 @@ export class ABFActor extends Actor {
     });
   }
 
-
   /**
    * Deletes a prepared spell from the `mystic.preparedSpells` array of the `ABFActor` class.
-   * 
+   *
    * @param spellName - The name of the spell to be deleted.
    * @param spellGrade - The grade of the spell to be deleted.
    * @returns None. The method updates the `mystic.preparedSpells` array of the actor.

--- a/src/module/migration/migrate.js
+++ b/src/module/migration/migrate.js
@@ -1,6 +1,7 @@
 import { ABFSettingsKeys } from '../../utils/registerSettings';
 import { ABFActor } from '../actor/ABFActor';
 import { ABFDialogs } from '../dialogs/ABFDialogs';
+import ABFItem from '../items/ABFItem';
 import * as MigrationList from './migrations';
 
 /** @typedef {import('./migrations/Migration').Migration} Migration */
@@ -27,65 +28,146 @@ function migrationApplies(migration) {
 }
 
 /**
+ * Migrates a collection of items. If the collection are items belonging to an actor or pack,
+ * a context needs to be provided for the `updateDocuments(...)` function.
+ * @param {ABFItem[]} items
  * @param {Migration} migration
+ * @param {{parent: ABFActor} | {pack: string} | {}} context - context for the Item.updateDocuments call
  */
-async function migrateAllActors(migration) {
-  if (migration.updateActor) {
-    // migrate world actors and unlinked token actors
-    const unlinkedTokenActors = game.scenes
-      .map(scene =>
-        scene.tokens
-          .filter(token => !token.actorLink && token.actor)
-          .map(token => token.actor)
-      )
-      .flat();
+async function migrateItemCollection(items, migration, context = {}) {
+  if (migration.filterItems) items = items.filter(migration.filterItems);
+  const length = items.length ?? items.size; // takes care of the case of a DocumentCollection
 
-    // add the actors in the compendia
-    const actorPacks = await Promise.all(
-      game.packs
-        .filter(pack => pack.metadata.type === 'Actor')
-        .map(async actorPack => {
-          const packObj = { pack: actorPack, wasLocked: actorPack.locked };
-          await actorPack.configure({ locked: false });
-          return packObj;
-        })
+  if (length === 0 || !migration.updateItem) return;
+  console.log(`AnimaBF | Migrating ${length} Items.`);
+
+  const migrated = await Promise.all(items.map(i => migration.updateItem(i)));
+
+  const updates = migrated
+    .map(i => {
+      if (!i) return;
+      const { _id, name, system } = i;
+      return { _id, name, system };
+    })
+    .filter(u => u);
+
+  await ABFItem.updateDocuments(updates, context);
+}
+
+/**
+ * Migrates a collection of actors, applying the migration to their owned items also.
+ * @param {ABFActor[]} actors
+ * @param {Migration} migration
+ * @param {{parent: ABFActor} | {pack: string} | {}} context - context for the updateDocuments calls
+ */
+async function migrateActorCollection(actors, migration, context = {}) {
+  if (migration.filterActors) actors = actors.filter(migration.filterActors);
+  const length = actors.length ?? actors.size; // takes care of the case of a DocumentCollection
+  if (length === 0 || (!migration.updateItem && !migration.updateActor)) return;
+  console.log(`AnimaBF | Migrating ${length} Actors.`);
+
+  if (migration.updateItem) {
+    await Promise.all(
+      actors.map(async a => migrateItemCollection(a.items, migration, { parent: a }))
     );
-    const compendiaActors = (
-      await Promise.all(
-        actorPacks.map(packObject => {
-          return packObject.pack.getDocuments();
-        })
-      )
-    ).flat();
-
-    /** @type {ABFActor[]} */
-    const actors = [...game.actors, ...unlinkedTokenActors, ...compendiaActors];
-
-    for (const actor of actors) {
-      console.log(`AnimaBF | Migrating actor ${actor.name} (${actor.id}).`);
-      const system = (await migration.updateActor(actor)).system;
-      await actor.update({ system });
-    }
-
-    // Lock again packs which where locked
-    actorPacks
-      .filter(packObject => packObject.wasLocked)
-      .forEach(async packObject => {
-        await packObject.pack.configure({ locked: true });
-      });
+  }
+  if (migration.updateActor) {
+    const migrated = await Promise.all(actors.map(a => migration.updateActor(a)));
+    const updates = migrated
+      .map(a => {
+        if (!a) return;
+        const { _id, name, system } = a;
+        return { _id, name, system };
+      })
+      .filter(u => !!u);
+    await ABFActor.updateDocuments(updates, context);
   }
 }
 
 /**
+ * Migrates the actors from unlinked tokens presents on a collection of scenes
+ * @param {Scene[]} scenes
  * @param {Migration} migration
- * @todo Implement this function
+ * @param {{parent: ABFActor} | {pack: string} | {}} context - context for the updateDocuments calls
  */
-function migrateItems(migration) {
-  if (migration.preUpdateItem || migration.updateItem) {
-    throw new Error(
-      'AnimaBF | Trying to update items with a migration, but `migrateItems()` function in `migrate.js` not defined yet'
-    );
-  }
+async function migrateUnlinkedActors(scenes, migration, context) {
+  const length = items.length || items.size; // takes care of the case of a DocumentCollection
+  if (length === 0 || (!migration.updateItem && !migration.updateActor)) return;
+
+  await Promise.all(
+    scenes.map(s =>
+      migrateActorCollection(
+        s.tokens
+          .filter(token => !token.actorLink && token.actor)
+          .map(token => token.actor),
+        migration,
+        context
+      )
+    )
+  );
+}
+
+/**
+ * Migrates world items
+ * @param {Migration} migration
+ */
+async function migrateWorldItems(migration) {
+  if (!migration.updateItem) return;
+  await migrateItemCollection(game.items, migration);
+}
+
+/**
+ * Migrates world actors (including unlinked tokens on world's scenes), and their owned items.
+ * @param {Migration} migration
+ */
+async function migrateWorldActors(migration) {
+  if (!migration.updateActor && !migration.updateItem) return;
+
+  migrateActorCollection(game.actors, migration);
+  migrateUnlinkedActors(game.scenes, migration);
+}
+
+/**
+ * @param {Migration} migration
+ */
+async function migratePacks(migration) {
+  // load packs with actors, items or scenes
+  const packTypes = migration.updateItem
+    ? ['Actor', 'Item', 'Scene']
+    : ['Actor', 'Scene'];
+
+  let packs = await Promise.all(
+    game.packs
+      .filter(pack => packTypes.includes(pack.metadata.type))
+      .map(async pack => {
+        const packObj = {
+          pack: pack,
+          wasLocked: pack.locked,
+          id: pack.metadata.id,
+          type: pack.metadata.type
+        };
+        await pack.configure({ locked: false });
+        packObj.documents = await pack.getDocuments();
+        return packObj;
+      })
+  );
+
+  const migrate = {
+    Actor: migrateActorCollection,
+    Item: migrateItemCollection,
+    Scene: migrateUnlinkedActors
+  };
+  await Promise.all(
+    packs.map(pack => migrate[pack.type](pack.documents, migration, { pack: pack.id }))
+  );
+  // Lock again packs which where locked
+  await Promise.all(
+    packs
+      .filter(packObject => packObject.wasLocked)
+      .map(async packObject => {
+        await packObject.pack.configure({ locked: true });
+      })
+  );
 }
 
 /**
@@ -108,9 +190,11 @@ async function applyMigration(migration) {
   try {
     console.log(`AnimaBF | Applying migration ${migration.version}.`);
 
-    await migrateAllActors(migration);
-    migrateItems(migration);
+    await migrateWorldItems(migration);
+    await migrateWorldActors(migration);
+    await migratePacks(migration);
     migrateTokens(migration);
+    migration.migrate?.();
 
     console.log(`AnimaBF | Migration ${migration.version} completed.`);
     game.settings.set(

--- a/src/module/migration/migrations/5-update-spells-powers.js
+++ b/src/module/migration/migrations/5-update-spells-powers.js
@@ -1,0 +1,54 @@
+/** @typedef {import('./Migration').Migration} Migration */
+
+const newItems = {
+  get ready() {
+    return !!this.spell && !!this.psychicPowers;
+  },
+  async init() {
+    if (this.ready) return;
+    this.spell = await game.packs.get('animabf.magic').getDocuments();
+    this.psychicPower = await game.packs.get('animabf.psychic').getDocuments();
+  },
+  async get(itemType, name) {
+    if (!this.ready) await this.init();
+    return this[itemType].find(i => i.name.toLowerCase() === name.toLowerCase());
+  }
+};
+
+/** @type Migration */
+export const Migration5UpdateSpellsPowers = {
+  version: 5,
+  title: 'Update inner spells and psychic powers to match compendia',
+  description:
+    'This migration updates existing spells and psychic powers to match some changes made on compendia. ' +
+    'Any custom description on spells or powers will be left unchanged. ' +
+    'Additionally, any custom spell or power will be left unchanged, but you will need to update ' +
+    'those manually for the newest features to work correctly.',
+  filterItems(item) {
+    return (
+      ['spell', 'psychicPower'].includes(item.type) &&
+      !['animabf.magic', 'animabf.psychic'].includes(item.pack)
+    );
+  },
+  filterActors(actor) {
+    return actor.items.filter(i => ['spell', 'psychicPower'].includes(i.type)).length > 0;
+  },
+  async updateItem(item) {
+    if (!['spell', 'psychicPower'].includes(item.type)) {
+      console.error('AnimaBF | spell/psychicPower filter not working');
+      return;
+    }
+
+    let name = item.name.includes('-') ? item.name.split(' - ')[1] : item.name;
+
+    let newItem = await newItems.get(item.type, name);
+    if (!newItem) return;
+
+    item.name = newItem.name;
+    const { system } = newItem;
+    system.description.value = item.system.description.value;
+    item.system = system;
+
+    return item;
+  }
+};

--- a/src/module/migration/migrations/Migration.d.ts
+++ b/src/module/migration/migrations/Migration.d.ts
@@ -23,13 +23,13 @@ export interface Migration {
    * This is a short title describing the purpose of the migration.
    * The title is displayed on the warning dialog before applying the migration.
    */
-  readonly title: string,
+  readonly title: string;
 
   /**
    * This is a longer description of the changes in the migration, supposed to be detailed but concise.
    * To be displayed on the warning dialog before applying the migration.
    */
-  readonly description: string,
+  readonly description: string;
 
   /**
    * Update the actor to the latest schema version.
@@ -39,21 +39,11 @@ export interface Migration {
   updateActor?(actor: ABFActor): ABFActor | Promise<ABFActor>;
 
   /**
-   * Update the item to the latest schema version, handling changes that must happen before any other migration in a
-   * given list.
-   * @param item - Item to update.
-   * @param actor - If the item is part of an actor, this is set to the actor itself
-   * @returns The item after the changes in the migration
-   */
-  preUpdateItem?(item: ABFItem, actor?: ABFActor): ABFItem | Promise<ABFItem>;
-
-  /**
    * Update the item to the latest schema version.
    * @param item - Item to update.
-   * @param actor - If the item is part of an actor, this is set to the actor itself
    * @returns The item after the changes in the migration
    */
-  updateItem?(item: ABFItem, actor?: ABFActor): ABFItem | Promise<ABFItem>;
+  updateItem?(item: ABFItem): ABFItem | Promise<ABFItem>;
 
   /**
    * Update the token to the latest schema version.
@@ -72,4 +62,14 @@ export interface Migration {
    * isn't actor or item related. This function will be called during the migration.
    */
   migrate?(): void;
+
+  /**
+   * Filter determining which items should be migrated. The filter is used inside Array.filter(...)
+   */
+  filterItems?(item: ABFItem): boolean;
+
+  /**
+   * Filter determining which actors should be migrated. The filter is used inside Array.filter(...)
+   */
+  filterActors?(actor: ABFActor): boolean;
 }

--- a/src/module/migration/migrations/index.js
+++ b/src/module/migration/migrations/index.js
@@ -1,13 +1,5 @@
-
-
-
-
-
 export { Migration1DefaultFumble } from './1-fix-defaul-fumble';
-
 export { Migration2MagicProjection } from './2-fix-magic-projection';
-
 export { Migration3AlternativeAct } from './3-fix-alternative-act';
-
 export { Migration4PsychicDisciplinesMentalPatterns } from './4-fix-psychic-disciplines-mental-patterns';
-
+export { Migration5UpdateSpellsPowers } from './5-update-spells-powers';

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "animabf",
   "title": "Anima Beyond Fantasy",
   "description": "Unofficial Anima Beyond Fantasy system for Foundry VTT",
-  "version": "1.18.0-beta4",
+  "version": "1.18.0-beta5",
   "compatibility": { "minimum": "11", "verified": "11.315" },
   "url": "https://github.com/AnimaBeyondDevelop/AnimaBeyondFoundry",
   "manifest": "https://raw.githubusercontent.com/AnimaBeyondDevelop/AnimaBeyondFoundry/main/src/system.json",


### PR DESCRIPTION
Para poder hacer las migraciones que necesitábamos y actualizar los hechizos y los poderes psíquicos que tengamos en el mundo con las versiones actualizadas de los compendios que subió @Lui-Sin, necesitábamos añadir las migraciones de items. He refactorizado un poco el sistema de migraciones para poder hacerlas. Novedades:
1. Ahora, las actualizaciones de documentos se hacen en masa usando `Document.updateDocuments()` en lugar de uno a uno.
2. Ahora hay filtros en las migraciones para decidir en qué objetos o actores se aplican.

Tras esta migración, los hechizos y poderes deberían tener actualizados los campos relativos a su uso en combate:
```json
"combatType": { "value": "" },
"critic": { "value": "-" },
"visible": false
```