### PR TITLE
Improve release script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-------.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-------.md
@@ -1,10 +1,9 @@
 ---
 name: "Bug report (\U0001F1EC\U0001F1E7)"
 about: Create a report to help us improve
-title: "[\U0001F1EC\U0001F1E7 - Bug] Here goes the title"
+title: '[EN - Bug] Here goes the title'
 labels: bug
 assignees: ''
-
 ---
 
 ### Information
@@ -23,7 +22,7 @@ assignees: ''
 
 1. Go to '...'
 2. Click in '....'
-...
+   ...
 
 #### Screenshots
 

--- a/.github/ISSUE_TEMPLATE/new-suggestion-------.md
+++ b/.github/ISSUE_TEMPLATE/new-suggestion-------.md
@@ -1,10 +1,9 @@
 ---
 name: "New suggestion (\U0001F1EC\U0001F1E7)"
 about: Suggest an idea for this project
-title: "[\U0001F1EC\U0001F1E7 - Feature request] Aquí el título de la sugerencia"
+title: '[EN - Feature request] Aquí el título de la sugerencia'
 labels: improvement
 assignees: ''
-
 ---
 
 ### Information

--- a/.github/ISSUE_TEMPLATE/nueva-sugerencia-------.md
+++ b/.github/ISSUE_TEMPLATE/nueva-sugerencia-------.md
@@ -1,10 +1,9 @@
 ---
 name: "Nueva sugerencia (\U0001F1EA\U0001F1F8)"
 about: Sugiere un nuevo elemento para el sistema
-title: "[\U0001F1EA\U0001F1F8 - Feature request] Aquí el título de la sugerencia"
+title: '[ES - Feature request] Aquí el título de la sugerencia'
 labels: improvement
 assignees: ''
-
 ---
 
 ### Información

--- a/.github/ISSUE_TEMPLATE/reportar-bug-------.md
+++ b/.github/ISSUE_TEMPLATE/reportar-bug-------.md
@@ -1,10 +1,9 @@
 ---
 name: "Reportar bug (\U0001F1EA\U0001F1F8)"
 about: Crear un reporte para ayudarnos a mejorar
-title: "[\U0001F1EA\U0001F1F8 - Bug] Aquí va el título"
+title: '[ES - Bug] Aquí va el título'
 labels: bug
 assignees: ''
-
 ---
 
 ### Información
@@ -23,7 +22,7 @@ assignees: ''
 
 1. Ir a '...'
 2. Click en '....'
-...
+   ...
 
 #### Screenshots
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Release to FoundryVTT
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Publish the release to FoundryVTT's package repository.
+      - name: Publish Module to FoundryVTT Website
+        id: publish_to_foundry_website
+        if: ${{ !github.event.release.unpublished && !github.event.release.prerelease }}
+        uses: cs96and/FoundryVTT-release-package@v1
+        with:
+          package-token: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}
+          manifest-url: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/system.json
+          dry-run: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,3 @@ jobs:
         with:
           package-token: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}
           manifest-url: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/system.json
-          dry-run: 1

--- a/scripts/release/release.js
+++ b/scripts/release/release.js
@@ -37,11 +37,22 @@ const { dry } = argv;
     throwError('Repository URLs not configured in distributionconfig.json');
   }
 
-  readlineSync.question(
+  const newVersion = readlineSync.question(
     chalk.magenta(
-      `Do you want to publish a new version? New version will be ${packageJson.version}, so make sure that this version is not already published :`
+      `Version number in package.json is ${packageJson.version}.` +
+        'Leave this blank or specify a new one and press enter: '
     )
   );
+
+  if (newVersion) {
+    log.info('Updating package.json file...');
+    packageJson.version = newVersion;
+    const prettiedPackageJson = prettier.format(JSON.stringify(packageJson), {
+      parser: 'json'
+    });
+
+    fs.writeFileSync('package.json', prettiedPackageJson, 'utf8');
+  }
 
   log.info('Updating system.json file...');
 
@@ -51,7 +62,9 @@ const { dry } = argv;
   systemFile.changelog = `${repoURL}/releases/tag/v${systemFile.version}`;
   systemFile.download = `${repoURL}/releases/download/v${systemFile.version}/${systemFile.id}.zip`;
 
-  const prettiedSystemFile = prettier.format(JSON.stringify(systemFile), { parser: 'json' });
+  const prettiedSystemFile = prettier.format(JSON.stringify(systemFile), {
+    parser: 'json'
+  });
 
   fs.writeFileSync('src/system.json', prettiedSystemFile, 'utf8');
 
@@ -77,6 +90,7 @@ const { dry } = argv;
   fs.mkdirSync('package');
 
   await zip('dist', `package/${systemFile.id}.zip`);
+  await fs.copyFile('./dist/system.json', './package/system.json');
 
   log.success('Package created...');
 
@@ -90,11 +104,30 @@ const { dry } = argv;
     log.warning('Dry mode activated, no tags will be pushed');
   }
 
-  readlineSync.question(
-    chalk.blue(
-      `Wait until create new release, click here to access directly: https://github.com/AnimaBeyondDevelop/AnimaBeyondFoundry/releases/new?title=v${systemFile.version}&tag=v${systemFile.version}\n\nRemember to upload de package ${systemFile.id}.zip allocated in package folder`
-    )
-  );
+  try {
+    if (!dry) {
+      execSync(
+        `gh release create v${systemFile.version} ./package/* --verify-tag --generate-notes --draft`
+      );
+    } else {
+      log.warning('Dry mode activated, no release will be created');
+    }
+  } catch (error) {
+    readlineSync.question(
+      chalk.blue(
+        'Create the release now using the link: ' +
+          `https://github.com/AnimaBeyondDevelop/AnimaBeyondFoundry/releases/new?title=v${systemFile.version}&tag=v${systemFile.version}` +
+          '\nPress any key to continue...'
+      )
+    );
+
+    readlineSync.question(
+      chalk.blue(
+        'Upload the contents of directory ./package (${systemFile.id}.zip and system.json) ' +
+          'and press any key when finished...'
+      )
+    );
+  }
 
   log.info('Cleaning files...');
 

--- a/scripts/release/release.js
+++ b/scripts/release/release.js
@@ -39,7 +39,7 @@ const { dry } = argv;
 
   const newVersion = readlineSync.question(
     chalk.magenta(
-      `Version number in package.json is ${packageJson.version}.` +
+      `Version number in package.json is ${packageJson.version}. ` +
         'Leave this blank or specify a new one and press enter: '
     )
   );


### PR DESCRIPTION
The release script allows now to introduce a new version number (and will update with it both package.json and system.json), and will auto-create the github release (auto-uploading attachments) if gh CLI command is present and configured.

It also removes the flags from issue templates (this was causing an issue with `gh dash`).