### PR TITLE
Use foundryvtt-cli to get the build destination path

### DIFF
--- a/docs/develop/es/es.md
+++ b/docs/develop/es/es.md
@@ -39,6 +39,7 @@ git clone https://github.com/AnimaBeyondDevelop/AnimaBeyondFoundry.git
 > echo "alias foundry='node $HOME/foundryvtt/resources/app/main.js --dataPath=$HOME/foundrydata'" >> ~/.bash_aliases
 >```
 > *Tras crear el alias (y reiniciar la terminal para que surta efecto), bastará con usar el comando `foundry` para lanzarlo. Para conectarse habrá que abrir cualquier explorador y abrir la url `localhost:30000`.*
+> *Aunque el alias es suficiente cuando se tiene una sola versión instalada, el cli de Foundry ([foundryvtt-cli](https://github.com/foundryvtt/foundryvtt-cli)) es una buena herramienta para gestionar distintas instalaciones. En [esta página](./foundry-cli.md) pueden encontrarse instrucciones para gestionar instalaciones con foundryvtt-cli.*
 
 ## Instrucciones de trabajo para desarrolladores
 

--- a/docs/develop/es/foundry-cli.md
+++ b/docs/develop/es/foundry-cli.md
@@ -1,0 +1,89 @@
+# Ventajas de usar el FoundryVtt-cli
+
+La principal ventaja es poder centralizar en una sola herramienta los paths de instalación y de datos de foundry. Así, con hacer
+
+```bash
+fvtt configure set installPath "/path/to/foundry/install"
+fvtt configure set dataPath "/path/to/foundry/data"
+```
+
+El CLI registra los paths correspondientes y para lanzar foundry tan sólo tendremos que hacer
+
+```bash
+fvtt launch
+```
+
+sin necesidad de indicar los paths cada vez que queramos lanzar foundry.
+
+Además, el foundry provee comandos para obtener dichos paths una vez establecidos:
+
+```bash
+fvtt configure get installPath # prints /path/to/foundry/install
+fvtt configure get dataPath # prints /path/to/foundry/data
+```
+
+Esto es útil para construir la ruta donde deben ir los sistemas, por ejemplo, y copiar allí el sistema una vez hecha la build. En concreto, si se encuentra instalado, no será necesario crear el archivo `foundryconfig.json` para especificar el `dataPath`, sino que se obtendrá a través del CLI.
+
+# Instalación
+
+La instalación es sencilla: se hace usando npm. Conviene instalarlo globalmente para tenerlo accesible desde la línea de comandos:
+
+```bash
+npm install -g @foudryvtt/foundryvtt-cli
+```
+
+Tras esto, sólo tendremos que configurar los paths como arriba y comprobar nuestra configuración haciendo `fvtt configure` (obtendremos un `configuration complete!` si está todo correcto).
+
+# Selector de versiones
+
+Si se instala el CLI, es posible tener un selector de versiones para cambiar entre las instaladas. En concreto, podemos tener la instalación de Foundry siguiendo esta estructura de carpetas:
+
+```
+/home/<user>
+├── data
+│  ├── v11
+│  └── v12
+└── installations
+   ├── v11
+   └── v12
+```
+
+En este caso, podemos valernos de ésta para crear una utilidad que nos permita cambiar de versiones de manera fácil:
+
+Copiando el código anterior a un archivo guardado en algún sitio en el path (por ejemplo `~/.local/bin/fvtt-config`) y dándole permisos de ejecución si es necesario (`chmod +x ~/.local/bin/fvtt-config`), deberíamos poder lanzar fvtt-config, que nos permitirá seleccionar una de las versiones instaladas y establecerá los paths correspondientes.
+
+> _Nota: aunque no es necesario, si fzf está instalado se usa para seleccionar la versión permitiéndonos buscar entre las disponibles._
+
+```bash
+#!/usr/bin/bash
+
+if ! [ -x "$(command -v fvtt)" ]
+then
+  echo "Error: fvtt not available."
+  echo "Please install it with 'npm install -g @foundryvtt/foundryvtt-cli'"
+  exit 1
+fi
+
+installPath=$HOME/foundry/installations
+
+if [ -x "$(command -v fzf)" ]
+then
+  version=$(ls $installPath | fzf --reverse --info=inline --height=10%)
+else
+  PS3="Select your version: "
+  select installation in $installPath/*
+  do
+    version=${installation#*installations/}
+    break
+  done
+fi
+
+if [ -z "$version" ]
+then
+  echo "No changes!"
+  fvtt configure view
+else
+  fvtt configure set installPath "$HOME/foundry/installations/$version"
+  fvtt configure set dataPath "$HOME/foundry/data/${version%.*}"
+fi
+```

--- a/scripts/copyDirectoryToFoundrySystem.js
+++ b/scripts/copyDirectoryToFoundrySystem.js
@@ -4,18 +4,27 @@ const { execSync } = require('child_process');
 const chalk = require('chalk');
 const fs = require('fs-extra');
 
-const config = fs.readJSONSync('foundryconfig.json');
-const directory = process.argv[2];
+const directory = process.argv[2] ?? 'animabf';
+let destPath;
 
 try {
-  fs.rmSync(`${config.destPath}/${directory}`, { recursive: true, force: true });
+  console.log(chalk.yellow('Trying to use fvtt to get dataPath...'));
+  dataPath = execSync('fvtt configure get dataPath', { encoding: 'utf8' }).trim();
+  destPath = `${dataPath}/Data/systems`;
+} catch (e) {
+  console.log(chalk.yellow('Falling back to foundryconfig.json'));
+  destPath = fs.readJSONSync('foundryconfig.json').destPath;
+}
+
+try {
+  fs.rmSync(`${destPath}/${directory}`, { recursive: true, force: true });
 } catch {
   // ignore
 }
 
 try {
-  execSync(`cp -r $(pwd)/dist ${config.destPath}/${directory}`);
-  console.log(chalk.green(`Directory ${directory} copied into ${config.destPath}\n\n`));
+  execSync(`cp -r $(pwd)/dist ${destPath}/${directory}`);
+  console.log(chalk.green(`Directory ${directory} copied into ${destPath}\n\n`));
 } catch (e) {
   console.error(chalk.red(e.stack));
 }


### PR DESCRIPTION
En #214 se incluyó el uso de foundryvtt-cli para gestionar los compendios. Trasteando he visto que puede ser útil usarlo también para tener varias versiones de foundry instaladas y poder cambiar "fácilmente" entre ellas. Al empezar a usarlo, he visto que tiene sentido extraer el path de la instalación de ahí si fvtt está instalado.

He modificado el script que copia la build a la carpeta de datos de foundry para obtener del cli la ubicación de dicha carpeta si éste está instalado (globalmente). En caso de que no esté instalado globalmente, lo ignora y usa el `destPath` que se encuentra en `foundryconfig.json`.

También he creado documentación (incluyendo el código para un script útil) explicando cómo cambiar el flujo de trabajo para usar el CLI para gestionar las versiones instaladas de Foundry.