### PR TITLE
FIX - El tipo de movimiento debe reducirse solo en multiplos de 20

### DIFF
--- a/src/module/actor/utils/prepareActor/calculations/actor/general/mutateMovementType.js
+++ b/src/module/actor/utils/prepareActor/calculations/actor/general/mutateMovementType.js
@@ -26,7 +26,7 @@ export const mutateMovementType = data => {
   movementType.final.value =
     movementType.mod.value +
     data.characteristics.primaries.agility.value +
-    Math.min(0, Math.floor(data.general.modifiers.allActions.final.value / 20)) +
+    Math.min(0, Math.ceil(data.general.modifiers.allActions.final.value / 20)) +
     armorsMovementRestrictions;
 
   movementType.final.value = Math.max(0, movementType.final.value);


### PR DESCRIPTION
Esta PR corrige un error en el cálculo de los penalizadores al tipo de movimiento.
El código estaba usando `Math.floor()` (y al ser números negativos el penalizador se aplicaba antes de llegar al número necesario).

fixes #197 

### Testing:
Se ha verificado que el cálculo del TM se ajusta correctamente según los nuevos criterios de penalización.

<details><summary>Evidencias - SIN Fix</summary>
<p>

![image](https://github.com/user-attachments/assets/c207802f-41d6-4236-a591-537f7e597f8c)

![image](https://github.com/user-attachments/assets/7d9a2929-522e-49e3-8388-31fb54589769)


</p>
</details> 

<details><summary>Evidencias - CON Fix</summary>
<p>

![image](https://github.com/user-attachments/assets/61d039a2-6878-43ca-ad14-c54bbc8523a0)

![image](https://github.com/user-attachments/assets/37df0961-f9b1-454f-a895-ea5224ce83db)



</p>
</details> 