### PR TITLE
FIX - Los penalizadores de armadura deben aplicarse solo cuando hay una armadura equipada

### DIFF
--- a/src/module/actor/utils/prepareActor/calculations/actor/modifiers/calculations/calculateArmorPhysicalPenalty.js
+++ b/src/module/actor/utils/prepareActor/calculations/actor/modifiers/calculations/calculateArmorPhysicalPenalty.js
@@ -18,5 +18,7 @@ export const calculateEquippedArmorsRequirement = data => {
 export const calculateArmorPhysicalPenalty = data => {
   const totalWearRequirement = calculateEquippedArmorsRequirement(data);
 
+  if (getEquippedArmors(data).length === 0) return 0;
+
   return Math.min(0, data.combat.wearArmor.value - totalWearRequirement);
 };


### PR DESCRIPTION
Esta PR corrige un error en el calculo de los penalizadores de penalizadores de Armaduras, en el caso de tener un valor negativo los penalizadores se aplicaban incluso si no llevaras armadura, se ha añadido un if statement que comprueba si llevas armaduras, si no es el caso el penalizador es siempre 0

fixes #203

### Testing:
Se ha verificado que con valores negativos (y positivos) de armadura los penalizadores se aplican cuando es pertinente.

<details><summary>Evidencias - SIN Fix</summary>
<p>

![image](https://github.com/user-attachments/assets/7e548a64-68aa-48ca-bee6-688fabc4c4be)


![image](https://github.com/user-attachments/assets/0fe37134-a0ba-41ee-ab42-69722b96b6bd)

</p>
</details> 

<details><summary>Evidencias - CON Fix</summary>
<p>

![image](https://github.com/user-attachments/assets/ab8c33e7-ada3-4640-8bdb-553e92860434)

![image](https://github.com/user-attachments/assets/ff822f59-f272-4637-89a9-50ce707fac23)




</p>
</details> 