### PR TITLE
FIX - Añadido el Sello de fuego y eliminado el sello de Tierra

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -166,7 +166,7 @@
   "anima.ui.domine.martialKnowledge.mk.title": "MK",
   "anima.ui.domine.martialKnowledge.title": "Martial Knowledge",
   "anima.ui.domine.nemesisSkills.title": "Nemesis Skills",
-  "anima.ui.domine.seals.earth.title": "Earth",
+  "anima.ui.domine.seals.fire.title": "Fire",
   "anima.ui.domine.seals.major.title": "Major",
   "anima.ui.domine.seals.metal.title": "Metal",
   "anima.ui.domine.seals.minor.title": "Minor",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -166,7 +166,7 @@
   "anima.ui.domine.martialKnowledge.mk.title": "CM",
   "anima.ui.domine.martialKnowledge.title": "Conocimiento Marcial",
   "anima.ui.domine.nemesisSkills.title": "Habilidades de Némesis",
-  "anima.ui.domine.seals.earth.title": "Tierra",
+  "anima.ui.domine.seals.fire.title": "Fuego",
   "anima.ui.domine.seals.major.title": "Mayor",
   "anima.ui.domine.seals.metal.title": "Metal",
   "anima.ui.domine.seals.minor.title": "Menor",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -162,7 +162,7 @@
   "anima.ui.domine.martialKnowledge.mk.title": "CM",
   "anima.ui.domine.martialKnowledge.title": "Connaissance Martiale",
   "anima.ui.domine.nemesisSkills.title": "Pouvoirs Némésis",
-  "anima.ui.domine.seals.earth.title": "Terre",
+  "anima.ui.domine.seals.fire.title": "Feu",
   "anima.ui.domine.seals.major.title": "Majeur",
   "anima.ui.domine.seals.metal.title": "Métal",
   "anima.ui.domine.seals.minor.title": "Mineur",

--- a/src/templates/actor/parts/domine/parts/seals.hbs
+++ b/src/templates/actor/parts/domine/parts/seals.hbs
@@ -13,24 +13,24 @@
   }}
     <div class='red-background'></div>
     <div class='seal-row'>
-      <p class='label seal-row-title'>{{localize "anima.ui.domine.seals.earth.title"}}</p>
+      <p class='label seal-row-title'>{{localize "anima.ui.domine.seals.wood.title"}}</p>
 
       {{>
       "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-        class="minor-earth-seal minor-seal"
+        class="minor-wood-seal minor-seal"
         hideTitle=true
         inputType="checkbox"
-        inputName="system.domine.seals.minor.earth.isActive.value"
-        inputValue=system.domine.seals.minor.earth.isActive.value
+        inputName="system.domine.seals.minor.wood.isActive.value"
+        inputValue=system.domine.seals.minor.wood.isActive.value
       }}
 
       {{>
       "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-        class="major-earth-seal major-seal"
+        class="major-wood-seal major-seal"
         hideTitle=true
         inputType="checkbox"
-        inputName="system.domine.seals.major.earth.isActive.value"
-        inputValue=system.domine.seals.major.earth.isActive.value
+        inputName="system.domine.seals.major.wood.isActive.value"
+        inputValue=system.domine.seals.major.wood.isActive.value
       }}
     </div>
     <div class='seal-row'>
@@ -47,7 +47,7 @@
 
       {{>
       "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-        class="major-earth-seal major-seal"
+        class="major-metal-seal major-seal"
         hideTitle=true
         inputType="checkbox"
         inputName="system.domine.seals.major.metal.isActive.value"
@@ -68,7 +68,7 @@
 
       {{>
       "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-        class="major-earth-seal major-seal"
+        class="major-wind-seal major-seal"
         hideTitle=true
         inputType="checkbox"
         inputName="system.domine.seals.major.wind.isActive.value"
@@ -89,7 +89,7 @@
 
       {{>
       "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-        class="major-earth-seal major-seal"
+        class="major-water-seal major-seal"
         hideTitle=true
         inputType="checkbox"
         inputName="system.domine.seals.major.water.isActive.value"
@@ -97,24 +97,24 @@
       }}
     </div>
     <div class='seal-row'>
-      <p class='label seal-row-title'>{{localize "anima.ui.domine.seals.wood.title"}}</p>
+      <p class='label seal-row-title'>{{localize "anima.ui.domine.seals.fire.title"}}</p>
 
       {{>
       "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-        class="minor-wood-seal minor-seal"
+        class="minor-fire-seal minor-seal"
         hideTitle=true
         inputType="checkbox"
-        inputName="system.domine.seals.minor.wood.isActive.value"
-        inputValue=system.domine.seals.minor.wood.isActive.value
+        inputName="system.domine.seals.minor.fire.isActive.value"
+        inputValue=system.domine.seals.minor.fire.isActive.value
       }}
 
       {{>
       "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
-        class="major-earth-seal major-seal"
+        class="major-fire-seal major-seal"
         hideTitle=true
         inputType="checkbox"
-        inputName="system.domine.seals.major.wood.isActive.value"
-        inputValue=system.domine.seals.major.wood.isActive.value
+        inputName="system.domine.seals.major.fire.isActive.value"
+        inputValue=system.domine.seals.major.fire.isActive.value
       }}
     </div>
   {{/"systems/animabf/templates/common/ui/group-body.hbs"}}


### PR DESCRIPTION
Esta PR ajusta los sellos del KI a lo estipulado en el Manual.
Se ha añadido el sello de fuego y se ha eliminado el de Tierra dejando en su lugar el de madera.
fixes #205

### Testing:
Se ha verificado que los nuevos sellos funcionan y se muestran en la ficha
<details><summary>Evidencias - CON Fix</summary>
<p>

![image](https://github.com/user-attachments/assets/e9a92955-b887-4e67-8e62-694a82bf7519)


</p>