### PR TITLE
FIX - El poder Psiquico Destrozar usa RF en vez de RP

### DIFF
--- a/src/packs/psychic_powers/psychicPower_Destrozar_qZYLb8n1LaMnncLs.json
+++ b/src/packs/psychic_powers/psychicPower_Destrozar_qZYLb8n1LaMnncLs.json
@@ -30,22 +30,22 @@
         "value": "Fatiga 2"
       },
       "140": {
-        "value": "100 RP"
+        "value": "100 RF"
       },
       "180": {
-        "value": "120 RP"
+        "value": "120 RF"
       },
       "240": {
-        "value": "140 RP"
+        "value": "140 RF"
       },
       "280": {
-        "value": "160 RP"
+        "value": "160 RF"
       },
       "320": {
-        "value": "180 RP"
+        "value": "180 RF"
       },
       "440": {
-        "value": "220 RP"
+        "value": "220 RF"
       }
     },
     "actionType": {


### PR DESCRIPTION
Se ha modificado el poder Destrozar para que ponga lo mismo que el manual, en losefectos a partir de muy dificil se debe resistir con Resistencia Física y no Psíquica como ponía antes.

fixes #227

<details><summary>Evidencias</summary>
<p>

![image](https://github.com/user-attachments/assets/5a802ea4-737c-4b62-9fc3-10bce67a4c5f)

![image](https://github.com/user-attachments/assets/eed00761-8ab9-4bc5-9f2e-4c91e3555940)



</p>
</details> 