### PR TITLE
Fix: image popout spam when GM updating base actor for unlinked tokens

### DIFF
--- a/src/module/actor/ABFActorSheet.js
+++ b/src/module/actor/ABFActorSheet.js
@@ -29,6 +29,7 @@ export default class ABFActorSheet extends ActorSheet {
         width: 1000,
         height: 850,
         submitOnChange: true,
+        viewPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER,
         tabs: [
           {
             navSelector: '.sheet-tabs',
@@ -73,18 +74,13 @@ export default class ABFActorSheet extends ActorSheet {
     return 1000;
   }
 
-  /**
-   * Tests if a given user has permission to render the ActorSheet.
-   * If it does not, instead of rendering the sheet, shows the Actor's portrait.
-   * @param {ABFActor} user
-   * @returns {boolean}
-   */
-  _canUserView(user) {
-    const canView = this.actor.testUserPermission(user, 'OBSERVER');
-    if (!canView) {
+  async _render(force, options = {}) {
+    // If user permission is exactly LIMITED, then display image popout and quit; else do normal render
+    if (force && this.actor.testUserPermission(game.user, 'LIMITED', { exact: true })) {
       this.displayActorImagePopout();
+      return;
     }
-    return canView;
+    return super._render(force, options);
   }
 
   displayActorImagePopout() {


### PR DESCRIPTION
Al lanzarse un `.update(...)` de los actores de tokens no linkeados, foundry estaba ejecutando un render (con `force=false`, por lo que en principio solo se actualizan fichas ya abiertas y no se abre ninguna nueva) de las fichas de los mismos (ver imagen). 
![imagen](https://github.com/user-attachments/assets/e3d06e0d-764e-4ad1-bb55-7a808a5a0bd1)
Por la anterior implementación (en #213), como el método `_canUserView()` se llama siempre al pasar por `sheet._render()` antes de comprobar el valor de `force`, eso estaba abriendo las imágenes en estos casos para todos los jugadores que no podían ver las fichas de los tokens no linkeados.

Ahora se abre el popout de la imagen desde la función `_render(...)`, sólo si es llamada con `force=true` y sólo si el usuario tiene exactamente el permiso `LIMITED` (antes se comprobaba que tuviese permiso _menor o igual_ que `LIMITED`).

También, ahora se usa la implementación de permisos por defecto de foundry, por lo que se ha modificado el permiso en las opciones de la aplicación para que puedan una ficha los usuarios con permiso `OBSERVER` (o mayor) del actor en cuestión.