### PR TITLE
Simplify logic for spellcasting methods in actor.

### DIFF
--- a/src/module/actor/ABFActor.js
+++ b/src/module/actor/ABFActor.js
@@ -389,13 +389,24 @@ export class ABFActor extends Actor {
    * @param {ABFItem} spell
    * @param {"base"|"intermediate"|"advanced"|"arcane"} spellGrade
    * @param {"override"|"accumulated"|"innate"|"prepared"} castMethod
-   * @param {{zeon: number, pool: number}} [increasedCost={zeon: 0, pool: 0}]
+   * @param {Object} [increasedZeon] The increased zeon cost for the spell.
+   * @param {number} [increasedZeon.accumulated=0] - The part of the increased zeon cost that needs
+   * to be accumulated. Defaults to 0
+   * @param {number} [increasedZeon.pool=0] - The part of the increased zeon cost that is automatically
+   * deduced from the character's zeon pool, without accumulating. Used for instance in metamagic.
+   * Defaults to 0.
    * @returns {boolean} A boolean value indicating whether the spell can be cast or not.
    */
-  canCastSpell(spell, spellGrade, castMethod, increasedCost = { zeon: 0, pool: 0 }) {
+  canCastSpell(
+    spell,
+    spellGrade,
+    castMethod,
+    increasedZeon = { accumulated: 0, pool: 0 }
+  ) {
     let canCast = false;
     let warningMessage = '';
-    let zeonCost = spell?.system.grades[spellGrade].zeon.value + increasedCost.zeon;
+    let zeonCost =
+      spell?.system.grades[spellGrade].zeon.value + (increasedZeon.accumulated ?? 0);
     let zeonPool = this.system.mystic.zeon.value;
 
     switch (castMethod) {
@@ -429,7 +440,7 @@ export class ABFActor extends Actor {
         return true;
       }
     }
-    if (zeonPool < increasedCost.pool) {
+    if (zeonPool < (increasedZeon.pool ?? 0)) {
       canCast = false;
       warningMessage = 'dialogs.spellCasting.warning.zeonPool';
     }
@@ -447,18 +458,42 @@ export class ABFActor extends Actor {
    * @param {ABFItem} spell
    * @param {"base"|"intermediate"|"advanced"|"arcane"} spellGrade
    * @param {"override"|"accumulated"|"innate"|"prepared"} castMethod
-   * @param {{zeon: number, pool: number}} [increasedCost={zeon: 0, pool: 0}]
+   * @param {Object} [increasedZeon] The increased zeon cost for the spell.
+   * @param {number} [increasedZeon.accumulated=0] - The part of the increased zeon cost that needs
+   * to be accumulated. Defaults to 0
+   * @param {number} [increasedZeon.pool=0] - The part of the increased zeon cost that is automatically
+   * deduced from the character's zeon pool, without accumulating. Used for instance in metamagic.
+   * Defaults to 0.
    */
-  castSpell(spell, spellGrade, castMethod, increasedCost = { zeon: 0, pool: 0 }) {
-    if (!this.canCastSpell(spell, spellGrade, castMethod, increasedCost)) return;
+  castSpell(spell, spellGrade, castMethod, increasedZeon = { accumulated: 0, pool: 0 }) {
+    if (!this.canCastSpell(spell, spellGrade, castMethod, increasedZeon)) return;
+    if (castMethod !== 'override') {
+      this.consumeZeon(increasedZeon.pool);
+    }
     if (castMethod === 'prepared') {
-      this.deletePreparedSpell(spellName, spellGrade);
+      this.deletePreparedSpell(spell.name, spellGrade);
       return;
     }
     if (castMethod === 'accumulated') {
-      const zeon = spell.system.grades[spellGrade].zeon.value;
+      const zeon =
+        spell?.system.grades[spellGrade].zeon.value + increasedZeon.accumulated;
       this.consumeAccumulatedZeon(zeon);
     }
+  }
+
+  /**
+   * Consumes zeon from an actor's zeon pool.
+   * @param {number} zeon - The amount of zeon to be consumed.
+   */
+  consumeZeon(zeon) {
+    const newZeon = this.system.mystic.zeon.value - zeon;
+    this.update({
+      system: {
+        mystic: {
+          zeon: { value: newZeon }
+        }
+      }
+    });
   }
 
   /**
@@ -875,4 +910,3 @@ export class ABFActor extends Actor {
     return this.getEmbeddedDocument('Item', itemId);
   }
 }
-

--- a/src/module/actor/ABFActor.js
+++ b/src/module/actor/ABFActor.js
@@ -17,7 +17,6 @@ import { psychicPotentialEffect } from '../combat/utils/psychicPotentialEffect.j
 import { psychicFatigueCheck } from '../combat/utils/psychicFatigueCheck.js';
 import { shieldBaseValueCheck } from '../combat/utils/shieldBaseValueCheck.js';
 import { shieldValueCheck } from '../combat/utils/shieldValueCheck.js';
-import { INITIAL_SPELL_CASTING_DATA } from '../types/mystic/SpellItemConfig.js';
 import ABFFoundryRoll from '../rolls/ABFFoundryRoll';
 import { openModDialog } from '../utils/dialogs/openSimpleInputDialog';
 import ABFItem from '../items/ABFItem';
@@ -383,116 +382,82 @@ export class ABFActor extends Actor {
   }
 
   /**
-   * Determines if a mystic character can cast a specific spell at a specific grade.
+   * Evaluates if this actor can cast a spell at a given spellgrade with certain casting method.
+   * This method is responsible for issuing notifications informing the user whenever casting
+   * is not possible.
    *
-   * @param spell - The spell object that contains information about the spell, including the
-   * zeon cost for each grade.
-   * @param {string} spellGrade - The grade of the spell that the character wants to cast.
-   * @param {{prepared: boolean, innate:boolean}} [casted] - An object that indicates whether the spell has been casted before,
-   * either as a prepared spell or an innate spell.
-   * Default is { prepared: false, innate: false }.
-   * @param {boolean} override - A flag that indicates whether to override the normal casting rules and
-   * allow the spell to be casted regardless of zeon points or previous casting.
-   * Default is false.
-   * @returns {import('../types/mystic/SpellItemConfig.js').SpellCasting} - An object that contains information about the zeon points,
-   * whether the spell can be cast (prepared or innate), if the spell has been casted, and
-   * whether the casting rules should be overridden.
+   * @param {ABFItem} spell
+   * @param {"base"|"intermediate"|"advanced"|"arcane"} spellGrade
+   * @param {"override"|"accumulated"|"innate"|"prepared"} castMethod
+   * @param {{zeon: number, pool: number}} [increasedCost={zeon: 0, pool: 0}]
+   * @returns {boolean} A boolean value indicating whether the spell can be cast or not.
    */
-  mysticCanCastEvaluate(
-    spell,
-    spellGrade,
-    casted = { prepared: false, innate: false },
-    override = false
-  ) {
-    const spellCasting = INITIAL_SPELL_CASTING_DATA;
-    spellCasting.casted = casted;
-    spellCasting.override = override;
-    spellCasting.zeon.accumulated = this.system.mystic.zeon.accumulated ?? 0;
+  canCastSpell(spell, spellGrade, castMethod, increasedCost = { zeon: 0, pool: 0 }) {
+    let canCast = false;
+    let warningMessage = '';
+    let zeonCost = spell?.system.grades[spellGrade].zeon.value + increasedCost.zeon;
+    let zeonPool = this.system.mystic.zeon.value;
 
-    if (override) {
-      return spellCasting;
+    switch (castMethod) {
+      case 'accumulated': {
+        let zeonAccumulated = this.system.mystic.zeon.accumulated;
+        canCast = zeonAccumulated >= zeonCost;
+        warningMessage = 'dialogs.spellCasting.warning.zeonAccumulated';
+        break;
+      }
+      case 'innate': {
+        let spellVia = spell?.system.via.value;
+        let innateMagic = this.system.mystic.innateMagic;
+        let innateVia = innateMagic.via.find(i => i.name == spellVia);
+        let innateMagicValue =
+          innateMagic.via.length !== 0 && innateVia
+            ? innateVia.system.final.value
+            : innateMagic.main.final.value;
+        canCast = innateMagicValue >= zeonCost;
+        warningMessage = 'dialogs.spellCasting.warning.innateMagic';
+        break;
+      }
+      case 'prepared': {
+        canCast =
+          this.getPreparedSpells().find(
+            ps => ps.name == spell.name && ps.system.grade.value == spellGrade
+          )?.system.prepared.value ?? false;
+        warningMessage = 'dialogs.spellCasting.warning.preparedSpell';
+        break;
+      }
+      case 'override': {
+        return true;
+      }
     }
-
-    spellCasting.zeon.cost = spell?.system.grades[spellGrade].zeon.value;
-    spellCasting.canCast.prepared =
-      this.system.mystic.preparedSpells.find(
-        ps => ps.name == spell.name && ps.system.grade.value == spellGrade
-      )?.system.prepared.value ?? false;
-    const spellVia = spell?.system.via.value;
-    const innateMagic = this.system.mystic.innateMagic;
-    const innateVia = innateMagic.via.find(i => i.name == spellVia);
-    const innateMagicValue =
-      innateMagic.via.length !== 0 && innateVia
-        ? innateVia.system.final.value
-        : innateMagic.main.final.value;
-    spellCasting.canCast.innate = innateMagicValue >= spellCasting.zeon.cost;
-
-    if (!spellCasting.canCast.innate) {
-      spellCasting.casted.innate = false;
+    if (zeonPool < increasedCost.pool) {
+      canCast = false;
+      warningMessage = 'dialogs.spellCasting.warning.zeonPool';
     }
-    if (!spellCasting.canCast.prepared) {
-      spellCasting.casted.prepared = false;
+    if (!canCast) {
+      ui.notifications.warn(game.i18n.localize(warningMessage));
     }
-    return spellCasting;
-  }
-
-  /**
-   * Evaluates the spell casting conditions and returns a boolean value indicating whether the
-   * spell can be cast or not.
-   *
-   * @param {import('../types/mystic/SpellItemConfig.js').SpellCasting} spellCasting - - An object that contains information about the zeon
-   * points, whether the spell can be cast (prepared or innate), if the spell has been casted,
-   * and whether the casting rules should be overridden.
-   * @returns {boolean} - A boolean value indicating whether the spell can be cast or not.
-   */
-  evaluateCast(spellCasting) {
-    const { i18n } = game;
-    const { canCast, casted, zeon, override } = spellCasting;
-    if (override) {
-      return false;
-    }
-    if (canCast.innate && casted.innate && canCast.prepared && casted.prepared) {
-      ui.notifications.warn(i18n.localize('dialogs.spellCasting.warning.mustChoose'));
-      return true;
-    }
-    if (canCast.innate && casted.innate) {
-      return;
-    } else if (!canCast.innate && casted.innate) {
-      ui.notifications.warn(i18n.localize('dialogs.spellCasting.warning.innateMagic'));
-      return true;
-    } else if (canCast.prepared && casted.prepared) {
-      return false;
-    } else if (!canCast.prepared && casted.prepared) {
-      return ui.notifications.warn(
-        i18n.localize('dialogs.spellCasting.warning.preparedSpell')
-      );
-    } else if (zeon.accumulated < zeon.cost) {
-      ui.notifications.warn(
-        i18n.localize('dialogs.spellCasting.warning.zeonAccumulated')
-      );
-      return true;
-    } else return false;
+    return canCast;
   }
 
   /**
    * Handles the casting of mystic spells by an actor in the ABFActor class.
+   * Calls this.canCastSpell() to check if the spell can be cast, this.consumeAccumulatedZeon()
+   * to update the accumulated zeon value and this.deletePreparedSpell() to update prepared spells.
    *
-   * @param {import('../types/mystic/SpellItemConfig.js').SpellCasting} spellCasting An object that contains information about the zeon points, whether the spell can be cast (prepared or innate), if the spell has been casted, and whether the casting rules should be overridden.
-   * @param {string} spellName The name of the spell being casted.
-   * @param {string} spellGrade The grade of the spell being casted.
+   * @param {ABFItem} spell
+   * @param {"base"|"intermediate"|"advanced"|"arcane"} spellGrade
+   * @param {"override"|"accumulated"|"innate"|"prepared"} castMethod
+   * @param {{zeon: number, pool: number}} [increasedCost={zeon: 0, pool: 0}]
    */
-  mysticCast(spellCasting, spellName, spellGrade) {
-    const { zeon, casted, override } = spellCasting;
-    if (override) {
-      return;
-    }
-    if (casted.innate) {
-      return;
-    }
-    if (casted.prepared) {
+  castSpell(spell, spellGrade, castMethod, increasedCost = { zeon: 0, pool: 0 }) {
+    if (!this.canCastSpell(spell, spellGrade, castMethod, increasedCost)) return;
+    if (castMethod === 'prepared') {
       this.deletePreparedSpell(spellName, spellGrade);
-    } else {
-      this.consumeAccumulatedZeon(zeon.cost);
+      return;
+    }
+    if (castMethod === 'accumulated') {
+      const zeon = spell.system.grades[spellGrade].zeon.value;
+      this.consumeAccumulatedZeon(zeon);
     }
   }
 

--- a/src/module/types/combat/SupernaturalShieldItemConfig.js
+++ b/src/module/types/combat/SupernaturalShieldItemConfig.js
@@ -94,5 +94,5 @@ export const SupernaturalShieldItemConfig = ABFItemConfigFactory({
       actor.newSupernaturalShield('psychic', power, powerDifficulty);
     }
   },
-  onUpdate(actor){};
+  async onUpdate(actor, changes) {}
 });

--- a/src/module/types/combat/SupernaturalShieldItemConfig.js
+++ b/src/module/types/combat/SupernaturalShieldItemConfig.js
@@ -3,6 +3,7 @@ import { openComplexInputDialog } from '../../utils/dialogs/openComplexInputDial
 import { openModDialog } from '../../utils/dialogs/openSimpleInputDialog';
 import { SpellGrades } from '../mystic/SpellItemConfig';
 import { ABFItemConfigFactory } from '../ABFItemConfig';
+import ABFFoundryRoll from '@module/rolls/ABFFoundryRoll';
 
 /**
  * Initial data for a new supernatural shield. Used to infer the type of the data inside `supernaturalShield.system`
@@ -48,26 +49,13 @@ export const SupernaturalShieldItemConfig = ABFItemConfigFactory({
     if (tab === 'mystic') {
       const spellID = results['new.mysticShield.id'];
       const spellGrade = results['new.mysticShield.grade'];
-      const castSpell = results['new.mysticShield.castSpell'];
-      const innate = castSpell == 'innate';
-      const prepared = castSpell == 'prepared';
-      const override = castSpell == 'override';
+      const castMethod = results['new.mysticShield.castSpell'];
       const spell = actor.system.mystic.spells.find(i => i._id == spellID);
-      if (!spell) {
-        return;
-      }
-      actor.setFlag('animabf', 'spellCastingOverride', override);
-      const spellCasting = actor.mysticCanCastEvaluate(
-        spell,
-        spellGrade,
-        { innate, prepared },
-        override
-      );
-      spellCasting.casted = { innate, prepared };
-      if (actor.evaluateCast(spellCasting)) {
-        return;
-      }
-      actor.mysticCast(spellCasting, spell.name, spellGrade);
+      if (!spell) return;
+
+      actor.setCastMethodOverride(castMethod)
+      actor.castSpell(spell, spellGrade, castMethod);
+
       actor.newSupernaturalShield('mystic', {}, 0, spell, spellGrade);
     } else if (tab === 'psychic') {
       const powerID = results['new.psychicShield.id'];
@@ -105,5 +93,6 @@ export const SupernaturalShieldItemConfig = ABFItemConfigFactory({
       }
       actor.newSupernaturalShield('psychic', power, powerDifficulty);
     }
-  }
+  },
+  onUpdate(actor){};
 });

--- a/src/module/types/mystic/SpellItemConfig.js
+++ b/src/module/types/mystic/SpellItemConfig.js
@@ -4,29 +4,14 @@ import { NoneWeaponCritic } from '../combat/WeaponItemConfig.js';
 import { ABFItemConfigFactory } from '../ABFItemConfig';
 
 /**
- * An object that contains information about the zeon points, whether the spell can be cast (prepared or innate), if and how the spell has been casted, and whether the casting rules should be overridden.
- * @typedef {object} SpellCasting
- * @property {{ accumulated: number, cost: number }} zeon - An object with properties `accumulated` (chacater accumulated zeon) and `cost` (zeon spell cost).
- * @property {{ prepared: boolean, innate: boolean }} canCast - An object that indicates whether the spell can be cast, either as a prepared spell or an innate spell.
- * @property {{ prepared: boolean, innate: boolean }} casted - An object that indicates whether the spell has been casted before, either as a prepared spell or an innate spell.
- * @property {boolean} override - A flag that indicates whether to override the normal casting rules and allow the spell to be casted regardless of zeon points or previous casting.
- */
-export const INITIAL_SPELL_CASTING_DATA = {
-  zeon: { accumulated: 0, cost: 0 },
-  canCast: { prepared: false, innate: false },
-  casted: { prepared: false, innate: false },
-  override: false
-};
-/**
- * @readonly
  * @enum {string}
  */
-export const SpellGrades = {
+export const SpellGrades = /** @type {const} */ ({
   BASE: 'base',
   INTERMEDIATE: 'intermediate',
   ADVANCED: 'advanced',
   ARCANE: 'arcane'
-};
+});
 /**
  * @readonly
  * @enum {string}


### PR DESCRIPTION
> [!WARNING]
> BREAKS (old) combat dialogs in main. This PR can only be merged together with new svelte combat.

This PR breaks combat dialogs, since they used the (old) removed methods. This is unimportant since we are completely rewriting the dialogs with the new svelte approach, and there we use the new methods.

We introduce two new methods, `actor.canCastSpell(spell, spellGrade, castMethod, increasedCost = { zeon: 0, pool: 0 })` and `castSpell(spell, spellGrade, castMethod, increasedCost = { zeon: 0, pool: 0 })`.
- `.canCastSpell(...)` is responsible for checking if the actor can cast the given spell at a particular `spellGrade` using a given `casMethod`, notifying the user if this is not the case.
- `.casSpell(...)` delegates in `canCastSpell(...)` to check if the actor can cast the spell, and then updates the actor accordingly to reflect the spell casting.