### PR TITLE
fix: route defense prompt to player when actor has multiple owners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ package/
 /packs
 
 *.code-workspace
+
+# Local Kiro/agents files
+.kiro/
+.agents/
+AGENTS.md

--- a/src/module/combat/websocket/ws-combat/util/canOwnerReceiveMessage.js
+++ b/src/module/combat/websocket/ws-combat/util/canOwnerReceiveMessage.js
@@ -11,5 +11,5 @@ export const canOwnerReceiveMessage = actor => {
 
   const activePlayers = game.users.players.filter(u => u.active);
 
-  return activePlayers.filter(u => actor.testUserPermission(u, 'OWNER')).length === 1;
+  return activePlayers.some(u => actor.testUserPermission(u, 'OWNER'));
 };


### PR DESCRIPTION
## Problem

  `canOwnerReceiveMessage` used `.filter(...).length === 1` which returned `false` when a player-controlled actor had 2+ active owners, causing the GM to receive the defense dialog instead of the player.

  ## Fix

  Replace `.filter(...).length === 1` with `.some(...)` — routes to the player as long as at least one active owner is online; GM only handles defense when no active player owner exists.