### PR TITLE
Feature/pruebas active effects y defensas múltiples

### DIFF
--- a/src/animabf.mjs
+++ b/src/animabf.mjs
@@ -33,6 +33,7 @@ import { FormulaEvaluator } from './utils/formulaEvaluator.js';
 import { registerHandlebarsPartials } from './utils/handlebarsPartials.js';
 
 import { macroCreators, macroExecutors } from './utils/macroCreatorRegistry.js';
+import { ensureLinkedEffectForItem } from './module/actor/utils/ensureLinkedEffectForItem.js';
 
 /* ------------------------------------ */
 /* Initialize system */
@@ -338,6 +339,45 @@ Hooks.on('chatMessage', (chatLog, message, chatData) => {
   chatData._animabfFormulaDone = true;
   chatLog.processMessage(replaced, chatData);
   return false;
+});
+
+// When a system "effect" Item is created on an actor (drop to a token,
+// macro, programmatic), make sure the matching ActiveEffect document also
+// exists on the actor. Previously this only happened from the sheet's
+// _onDropItem, so dropping an effect onto a token never created the AE and
+// the modifiers were never applied until the user re-dragged through the
+// sheet.
+Hooks.on('createItem', async (item, _options, userId) => {
+  if (userId !== game.user.id) return;
+  if (item?.type !== 'effect') return;
+  const actor = item.parent;
+  if (!actor) return;
+  await ensureLinkedEffectForItem(actor, item);
+});
+
+// Allow dropping system "effect" items directly onto a token on the canvas.
+// Foundry V13 does not route this drop into the token's actor by default for
+// our effect type, so the item never reaches the sheet's _onDropItem flow.
+// We intercept the canvas drop, resolve the token under the cursor and
+// create the item ourselves; the createItem hook above then materializes the
+// linked ActiveEffect.
+Hooks.on('dropCanvasData', async (canvas, data) => {
+  if (data?.type !== 'Item' || !data.uuid) return;
+
+  const droppedItem = await fromUuid(data.uuid);
+  if (!droppedItem || droppedItem.type !== 'effect') return;
+
+  const gridSize = canvas.grid?.size ?? 100;
+  const hit = canvas.tokens?.placeables?.find(t => {
+    const w = (t.document?.width ?? 1) * gridSize;
+    const h = (t.document?.height ?? 1) * gridSize;
+    return data.x >= t.x && data.x <= t.x + w &&
+           data.y >= t.y && data.y <= t.y + h;
+  });
+  if (!hit?.actor) return;
+
+  await hit.actor.createEmbeddedDocuments('Item', [droppedItem.toObject()]);
+  return false; // Prevent the default drop handling
 });
 
 Hooks.on('renderActiveEffectConfig', (app, html) => {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -727,6 +727,7 @@
   "macros.combat.dialog.defense.title": "Defense",
   "macros.combat.dialog.defenseButton.title": "Send defense",
   "macros.combat.dialog.defenseCount.title": "Defense penalty",
+  "macros.combat.dialog.defenseCount.exemption.supernaturalShield": "Supernatural shields do not apply the multiple-defenses penalty",
   "macros.combat.dialog.defenseSent.title": "Defense sent. Waiting for combat results...",
   "macros.combat.dialog.defenseType.block.title": "Block",
   "macros.combat.dialog.defenseType.dodge.title": "Dodge",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -727,6 +727,7 @@
   "macros.combat.dialog.defense.title": "Defensa",
   "macros.combat.dialog.defenseButton.title": "Enviar defensa",
   "macros.combat.dialog.defenseCount.title": "Penalizador por defensa continua",
+  "macros.combat.dialog.defenseCount.exemption.supernaturalShield": "Los escudos sobrenaturales no aplican penalizador por defensa continua",
   "macros.combat.dialog.defenseSent.title": "Defensa enviada. Esperando a los resultados del combate...",
   "macros.combat.dialog.defenseType.block.title": "Bloqueo",
   "macros.combat.dialog.defenseType.dodge.title": "Esquiva",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -656,6 +656,7 @@
   "macros.combat.dialog.defense.title": "Défense",
   "macros.combat.dialog.defenseButton.title": "Envoyer la défense",
   "macros.combat.dialog.defenseCount.title": "Malus de Défense",
+  "macros.combat.dialog.defenseCount.exemption.supernaturalShield": "Les boucliers surnaturels n'appliquent pas le malus de défense multiple",
   "macros.combat.dialog.defenseSent.title": "Défense envoyée. Attente des résultats du combat...",
   "macros.combat.dialog.defenseType.block.title": "Parade",
   "macros.combat.dialog.defenseType.dodge.title": "Esquive",

--- a/src/module/SidebarDirectories/ABFActorDirectory.js
+++ b/src/module/SidebarDirectories/ABFActorDirectory.js
@@ -30,6 +30,44 @@ export default class ABFActorDirectory extends ActorDirectoryV1 {
   }
 
   /**
+   * Intercept drops over an actor row in the sidebar so dragging a system
+   * "effect" Item onto an actor in the directory creates the Item on that
+   * actor (Foundry V13 does not route this drop by default). Once the Item
+   * exists, the global createItem hook materializes the linked ActiveEffect,
+   * matching the behaviour of drops over a token on the canvas and drops
+   * over an open sheet.
+   *
+   * @param {DragEvent} event
+   */
+  async _onDrop(event) {
+    let data;
+    try {
+      const TE = foundry.applications?.ux?.TextEditor?.implementation ?? TextEditor;
+      data = typeof TE?.getDragEventData === 'function'
+        ? TE.getDragEventData(event)
+        : JSON.parse(event.dataTransfer.getData('text/plain'));
+    } catch {
+      data = null;
+    }
+
+    if (data?.type === 'Item' && data.uuid) {
+      const row = event.target?.closest?.('[data-entry-id], [data-document-id]');
+      const actorId = row?.dataset?.entryId ?? row?.dataset?.documentId;
+      const actor = actorId ? game.actors.get(actorId) : null;
+
+      if (actor) {
+        const item = await fromUuid(data.uuid);
+        if (item?.type === 'effect') {
+          await actor.createEmbeddedDocuments('Item', [item.toObject()]);
+          return;
+        }
+      }
+    }
+
+    return super._onDrop?.(event);
+  }
+
+  /**
    * Muestra el diálogo para importar desde Excel
    * @param {Actor} document
    * @returns {Promise<void>}

--- a/src/module/actor/ABFActorSheet.js
+++ b/src/module/actor/ABFActorSheet.js
@@ -13,6 +13,7 @@ import { ABFSettingsKeys } from '../../utils/registerSettings';
 import { createClickHandlers } from './utils/createClickHandlers';
 import { TypeEditorRegistry } from './types/TypeEditorRegistry.js';
 import { findEffectLinkedToItem } from './utils/findEffectLinkedToItem.js';
+import { ensureLinkedEffectForItem } from './utils/ensureLinkedEffectForItem.js';
 
 /** @typedef {import('./constants').TActorData} TData */
 /** @typedef {typeof FormApplication<FormApplicationOptions, TData, TData>} TFormApplication */
@@ -616,28 +617,7 @@ export default class ABFActorSheet extends ActorSheetV1 {
   }
 
   async _ensureEffectForItem(item) {
-    if (!item) return null;
-
-    const effect = this._getLinkedEffect(item);
-    if (effect) return effect;
-
-    const rawBaseData = item.system?.effectData ?? {};
-    // Ignore old origin if it exists in stored data
-    const { origin, ...baseData } = rawBaseData;
-
-    const data = foundry.utils.mergeObject(
-      {
-        name: item.name,
-        icon: item.img || 'icons/svg/aura.svg',
-        disabled: !item.system?.active,
-        origin: item.uuid // always the current item
-      },
-      baseData,
-      { inplace: false }
-    );
-
-    const [created] = await this.actor.createEmbeddedDocuments('ActiveEffect', [data]);
-    return created ?? null;
+    return ensureLinkedEffectForItem(this.actor, item);
   }
 
   async _onDropItem(event, data) {

--- a/src/module/actor/ABFActorSheet.js
+++ b/src/module/actor/ABFActorSheet.js
@@ -12,6 +12,7 @@ import { Logger } from '../../utils';
 import { ABFSettingsKeys } from '../../utils/registerSettings';
 import { createClickHandlers } from './utils/createClickHandlers';
 import { TypeEditorRegistry } from './types/TypeEditorRegistry.js';
+import { findEffectLinkedToItem } from './utils/findEffectLinkedToItem.js';
 
 /** @typedef {import('./constants').TActorData} TData */
 /** @typedef {typeof FormApplication<FormApplicationOptions, TData, TData>} TFormApplication */
@@ -606,7 +607,7 @@ export default class ABFActorSheet extends ActorSheetV1 {
 
   _getLinkedEffect(item) {
     if (!item) return null;
-    return this.actor.effects.find(e => e.origin === item.uuid) ?? null;
+    return findEffectLinkedToItem(this.actor, item);
   }
 
   async _linkItemToEffect(item, effect) {

--- a/src/module/actor/utils/activeEffectsBreakdown.js
+++ b/src/module/actor/utils/activeEffectsBreakdown.js
@@ -1,0 +1,108 @@
+// /module/actor/utils/activeEffectsBreakdown.js
+
+/**
+ * Normalize an Active Effect change to a logical mode string.
+ * Kept in sync with the resolver in activeEffectApplicator.js — we cannot
+ * import from inside the effectFow folder here because this helper is
+ * consumed from UI/dialog code that should not depend on the full effect
+ * flow machinery.
+ */
+function normalizeChangeMode(change) {
+  if (typeof change?.type === 'string') return change.type;
+  switch (change?.mode) {
+    case 1: return 'multiply';
+    case 2: return 'add';
+    case 3: return 'override'; // DOWNGRADE -> treated as override
+    case 4: return 'override'; // UPGRADE   -> treated as override
+    case 5: return 'override';
+    default: return 'add';
+  }
+}
+
+function getProp(obj, path) {
+  if (!obj || !path) return undefined;
+  const keys = path.split('.');
+  let cur = obj;
+  for (const k of keys) {
+    if (cur == null) return undefined;
+    cur = cur[k];
+  }
+  return cur;
+}
+
+/**
+ * Inspect the active Active Effects on an actor and return a structured
+ * breakdown of every change that targets a specific data path (e.g.
+ * 'system.combat.attack.final.value').
+ *
+ * Used by the combat dialog and the chat-attack template to show which AE
+ * contributed how much to a given roll. Restores the traceability that was
+ * lost when AE started writing directly to *.final.value.
+ *
+ * @param {object} actor  Foundry actor. Reads `actor.effects.contents`,
+ *                        `actor` itself for the current value (post-AE) and
+ *                        `actor._source.system` for the pre-AE source value.
+ * @param {string} path   Dot-path to inspect, must start with 'system.'.
+ *                        E.g. 'system.combat.attack.final.value'.
+ * @returns {{
+ *   total: number,
+ *   linearTotal: number,
+ *   hasNonLinear: boolean,
+ *   items: Array<{
+ *     effectId: string,
+ *     effectName: string,
+ *     mode: 'add'|'multiply'|'override',
+ *     value: number|string,
+ *     isLinear: boolean
+ *   }>
+ * }}
+ */
+export function getActiveEffectsBreakdownForPath(actor, path) {
+  const items = [];
+  let linearTotal = 0;
+  let hasNonLinear = false;
+
+  const effects = actor?.effects?.contents ?? [];
+  for (const effect of effects) {
+    if (!effect.active) continue;
+
+    const changes = effect.changes;
+    if (!Array.isArray(changes) || changes.length === 0) continue;
+
+    for (const change of changes) {
+      if (change?.key !== path) continue;
+
+      const mode = normalizeChangeMode(change);
+      const numeric = Number(change.value);
+      const value = Number.isNaN(numeric) ? change.value : numeric;
+      const isLinear = mode === 'add' && typeof value === 'number';
+
+      items.push({
+        effectId: String(effect.id ?? ''),
+        effectName: String(effect.name ?? effect.label ?? '?'),
+        mode,
+        value,
+        isLinear
+      });
+
+      if (isLinear) {
+        linearTotal += value;
+      } else {
+        hasNonLinear = true;
+      }
+    }
+  }
+
+  // Authoritative total = current value (with AE applied) minus the source
+  // value (before AE). This is the diff the AE flow actually produced and is
+  // robust against any future code that also writes to the path.
+  const currentRaw = getProp(actor, path);
+  const sourcePath = path.startsWith('system.') ? path.slice('system.'.length) : path;
+  const sourceRaw = getProp(actor?._source?.system, sourcePath);
+
+  const current = Number(currentRaw) || 0;
+  const source = Number(sourceRaw) || 0;
+  const total = current - source;
+
+  return { total, linearTotal, hasNonLinear, items };
+}

--- a/src/module/actor/utils/activeEffectsBreakdown.test.js
+++ b/src/module/actor/utils/activeEffectsBreakdown.test.js
@@ -1,0 +1,204 @@
+import { getActiveEffectsBreakdownForPath } from './activeEffectsBreakdown.js';
+
+/**
+ * Build a minimal actor stub:
+ *  - `_source.system` holds the pre-AE value (what the GM has in the sheet).
+ *  - `system` holds the post-AE value (what would be read after the flow).
+ *  - `effects.contents` is an array of effect stubs with `active` and
+ *    `changes` exactly as a Foundry ActiveEffect would expose them.
+ */
+const makeActor = ({ sourceAttack, currentAttack, effects }) => ({
+  _source: {
+    system: {
+      combat: { attack: { final: { value: sourceAttack } } }
+    }
+  },
+  system: {
+    combat: { attack: { final: { value: currentAttack } } }
+  },
+  effects: { contents: effects }
+});
+
+const ATTACK_PATH = 'system.combat.attack.final.value';
+
+describe('getActiveEffectsBreakdownForPath', () => {
+  it('returns an empty breakdown when no effects target the path', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 100,
+      effects: []
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(0);
+    expect(res.linearTotal).toBe(0);
+    expect(res.hasNonLinear).toBe(false);
+    expect(res.items).toEqual([]);
+  });
+
+  it('lists a single add effect with its name and value', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 120,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Sangre de Orochi',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(20);
+    expect(res.linearTotal).toBe(20);
+    expect(res.hasNonLinear).toBe(false);
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0]).toMatchObject({
+      effectName: 'Sangre de Orochi',
+      mode: 'add',
+      value: 20,
+      isLinear: true
+    });
+  });
+
+  it('skips effects that are not active', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 100,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Sangre de Orochi',
+          active: false,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(0);
+    expect(res.items).toEqual([]);
+  });
+
+  it('skips changes that target a different path', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 100,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Some Block Buff',
+          active: true,
+          changes: [{ key: 'system.combat.block.final.value', value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(0);
+    expect(res.items).toEqual([]);
+  });
+
+  it('sums multiple linear adds and lists them individually', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 90, // +20 -30 = -10 net
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Sangre de Orochi',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        },
+        {
+          id: 'eff2',
+          name: 'Ceguera parcial',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '-30', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(-10);
+    expect(res.linearTotal).toBe(-10);
+    expect(res.hasNonLinear).toBe(false);
+    expect(res.items).toHaveLength(2);
+    expect(res.items.map(i => i.effectName)).toEqual(['Sangre de Orochi', 'Ceguera parcial']);
+  });
+
+  it('marks override effects as non-linear and does not include them in linearTotal', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 999,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Override Test',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '999', type: 'override' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(899); // current - source
+    expect(res.linearTotal).toBe(0);
+    expect(res.hasNonLinear).toBe(true);
+    expect(res.items[0].isLinear).toBe(false);
+    expect(res.items[0].mode).toBe('override');
+  });
+
+  it('handles Foundry-standard numeric mode (mode: 2 = ADD)', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 115,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Native AE',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '15', mode: 2 }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(15);
+    expect(res.items[0].isLinear).toBe(true);
+    expect(res.items[0].mode).toBe('add');
+  });
+
+  it('total reflects the actor diff even if items disagree (defensive)', () => {
+    // Edge case: items report +20 but the actor diff says -5. This can
+    // happen if some other code path also writes to the field, or if the
+    // AE flow has not run yet. We trust the actor diff as the authoritative
+    // total; items remain for nominal display.
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 95,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Listed',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(-5);          // actor diff
+    expect(res.linearTotal).toBe(20);    // sum of listed items
+  });
+});

--- a/src/module/actor/utils/aeBreakdownFormat.js
+++ b/src/module/actor/utils/aeBreakdownFormat.js
@@ -1,0 +1,31 @@
+// /module/actor/utils/aeBreakdownFormat.js
+
+/**
+ * Build the HTML snippet appended to a roll's flavor that lists the Active
+ * Effects contributing to an attribute used in the roll. Linear (add)
+ * effects show their signed delta; non-linear effects (multiply/override)
+ * are labelled so the GM knows the formula could not split them out
+ * cleanly.
+ *
+ * Shared between CombatAttackDialog and AttackConfigurationDialog (and any
+ * future dialog that wants to expose the same nominal trace in chat).
+ *
+ * @param {{items: Array, hasNonLinear: boolean}} breakdown
+ * @returns {string} HTML to append to a roll flavor, empty if no items.
+ */
+export function formatAeBreakdownForFlavor(breakdown) {
+  if (!breakdown?.items?.length) return '';
+
+  const parts = breakdown.items.map(it => {
+    if (it.isLinear) {
+      const sign = it.value >= 0 ? '+' : '';
+      return `${it.effectName} (${sign}${it.value})`;
+    }
+    // Non-linear: don't claim a delta we cannot honestly show.
+    const tag = it.mode === 'override' ? 'override' : it.mode;
+    return `${it.effectName} (${tag})`;
+  });
+
+  const label = breakdown.hasNonLinear ? 'Mod (no descompuesto)' : 'Mod';
+  return `<br><small><em>${label}: ${parts.join(', ')}</em></small>`;
+}

--- a/src/module/actor/utils/effectFow/applicators/activeEffectApplicator.js
+++ b/src/module/actor/utils/effectFow/applicators/activeEffectApplicator.js
@@ -1,8 +1,40 @@
 // /module/actor/utils/effectFow/applicators/activeEffectApplicator.js
 
+/**
+ * Normalize a change's mode to one of the four operations we know how to
+ * apply: 'add' | 'multiply' | 'override' | 'custom'.
+ *
+ * Active Effect changes can arrive in two shapes:
+ *  - Legacy custom shape: `change.type` is a string ("add", "multiply",
+ *    "override"). This is what items effect persist in
+ *    `system.effectData.changes` and what the in-system flow has historically
+ *    produced.
+ *  - Foundry-standard shape: `change.mode` is a numeric constant per
+ *    CONST.ACTIVE_EFFECT_MODES. Any AE that goes through Foundry's schema
+ *    validation (e.g. created via the native UI, or after a save/load cycle)
+ *    arrives in this shape.
+ *
+ * Accepting both keeps existing data working while also supporting AEs that
+ * use the standard API.
+ *
+ * @param {{type?: string, mode?: number}} change
+ * @returns {'add'|'multiply'|'override'|'custom'}
+ */
+function resolveChangeMode(change) {
+  if (typeof change?.type === 'string') return change.type;
+  switch (change?.mode) {
+    case 1: return 'multiply'; // CONST.ACTIVE_EFFECT_MODES.MULTIPLY
+    case 2: return 'add';      // CONST.ACTIVE_EFFECT_MODES.ADD
+    case 3: return 'override'; // CONST.ACTIVE_EFFECT_MODES.DOWNGRADE -> treated as override
+    case 4: return 'override'; // CONST.ACTIVE_EFFECT_MODES.UPGRADE   -> treated as override
+    case 5: return 'override'; // CONST.ACTIVE_EFFECT_MODES.OVERRIDE
+    default: return 'add';     // CUSTOM (0) or undefined: default to add
+  }
+}
+
 export function applySingleActiveEffectChange(actor, effect, change) {
   const key = change.key;
-  const mode = change.type;
+  const mode = resolveChangeMode(change);
 
   const rawValue =
     typeof actor._applyDynamicEffectValue === 'function'
@@ -32,7 +64,10 @@ export function applySingleActiveEffectChange(actor, effect, change) {
       break;
 
     case 'override':
-      nextValue = rawValue;
+      // If the AE value is a numeric string ("99"), coerce to number so the
+      // resulting field stays numeric and downstream calculations don't break
+      // on string concatenation.
+      nextValue = !Number.isNaN(numericValue) ? numericValue : rawValue;
       break;
 
     default:

--- a/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.js
+++ b/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.js
@@ -22,15 +22,24 @@ function getFlaggedDeps(effect, index) {
 }
 
 /**
- * Maps an ActiveEffect mode to a write kind.
- * - OVERRIDE => overwrite
- * - others   => modify
+ * Maps an ActiveEffect change mode to a write kind.
  *
- * @param {number} mode
+ * Tolerates both formats:
+ *  - legacy custom string mode in `change.type` (e.g. "override", "add"),
+ *    which is what items effect store in `system.effectData.changes` and what
+ *    the in-system custom flow has historically produced.
+ *  - Foundry-standard numeric mode in `change.mode`, used by any AE that
+ *    passes through Foundry's EffectChangeData schema (every AE created via
+ *    Foundry's native UI, or after schema normalization). OVERRIDE = 5 per
+ *    CONST.ACTIVE_EFFECT_MODES.
+ *
+ * @param {{type?: string, mode?: number}} change
  * @returns {'overwrite'|'modify'}
  */
-function writeKindFromAEMode(type) {
-  return type === 'override' ? 'overwrite' : 'modify';
+function writeKindFromAEMode(change) {
+  if (change?.type === 'override') return 'overwrite';
+  if (change?.mode === 5) return 'overwrite'; // CONST.ACTIVE_EFFECT_MODES.OVERRIDE
+  return 'modify';
 }
 
 /**
@@ -47,7 +56,7 @@ export function buildActiveEffectChangeOp(effect, index, change) {
   const deps = normalizePaths([...flagged, ...inferred]);
 
   const [path] = normalizePaths([change.key]);
-  const kind = writeKindFromAEMode(change.type);
+  const kind = writeKindFromAEMode(change);
 
   return {
     id: `ae:${effect.id}:${index}`,
@@ -73,7 +82,14 @@ export function buildActiveEffectChangeOps(actor) {
   for (const effect of actor.effects?.contents ?? []) {
     if (!effect.active) continue;
 
-    const changes = effect.system.changes;
+    // Foundry's ActiveEffect stores changes at the top-level `effect.changes`
+    // (see EffectChangeData schema). The previous reading of
+    // `effect.system.changes` was always empty/undefined because Foundry does
+    // not place changes under the system data; that single line silently broke
+    // every Active Effect in the system (Sangre de Orochi, Ceguera, Derribado,
+    // ...) - they appeared active on the token but their changes were never
+    // applied.
+    const changes = effect.changes;
     if (!Array.isArray(changes) || changes.length === 0) continue;
 
     for (let i = 0; i < changes.length; i++) {

--- a/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
+++ b/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
@@ -1,0 +1,193 @@
+import {
+  buildActiveEffectChangeOp,
+  buildActiveEffectChangeOps
+} from './buildActiveEffectOps.js';
+import { applySingleActiveEffectChange } from '../../applicators/activeEffectApplicator.js';
+
+/**
+ * Regression tests for the bug where Active Effects items were not being
+ * applied to the actor during prepareActor's effect flow.
+ *
+ * Two root causes were identified:
+ *  1. buildActiveEffectChangeOps read `effect.system.changes` instead of the
+ *     Foundry-standard `effect.changes` top-level property, so the loop never
+ *     iterated and zero ops were produced.
+ *  2. The applicator/builder only matched the legacy custom string mode (e.g.
+ *     `change.type === 'add'`) and missed the Foundry-standard numeric
+ *     `change.mode` (CONST.ACTIVE_EFFECT_MODES.ADD = 2). Any AE created
+ *     through Foundry's standard schema validation lost its mode and
+ *     defaulted to the no-op branch.
+ *
+ * Both layers are exercised here so the contract stays honest going forward.
+ */
+
+const mkEffect = (id, changes, { active = true } = {}) => ({
+  id,
+  active,
+  priority: 0,
+  changes,
+  // legacy nested data the OLD builder used to look at — kept null to prove
+  // the new builder no longer relies on it
+  system: {}
+});
+
+describe('buildActiveEffectChangeOps', () => {
+  it('reads changes from effect.changes (top-level), not effect.system.changes', () => {
+    const effect = mkEffect('eff1', [
+      { key: 'system.combat.attack.final.value', value: '20', type: 'add', priority: null }
+    ]);
+
+    const actor = { effects: { contents: [effect] } };
+
+    const ops = buildActiveEffectChangeOps(actor);
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0].id).toBe('ae:eff1:0');
+    expect(ops[0].writes[0].path).toBe('system.combat.attack.final.value');
+  });
+
+  it('skips effects that are not active', () => {
+    const effect = mkEffect(
+      'eff2',
+      [{ key: 'system.combat.attack.final.value', value: '20', type: 'add' }],
+      { active: false }
+    );
+
+    const actor = { effects: { contents: [effect] } };
+
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(0);
+  });
+
+  it('emits one op per change', () => {
+    const effect = mkEffect('eff3', [
+      { key: 'system.combat.attack.final.value', value: '10', type: 'add' },
+      { key: 'system.combat.block.final.value', value: '10', type: 'add' },
+      { key: 'system.combat.dodge.final.value', value: '-30', type: 'add' }
+    ]);
+
+    const actor = { effects: { contents: [effect] } };
+
+    const ops = buildActiveEffectChangeOps(actor);
+    expect(ops).toHaveLength(3);
+  });
+});
+
+describe('applySingleActiveEffectChange', () => {
+  /**
+   * Minimal actor stub: a plain object with a `system` tree we can read/write
+   * with foundry.utils.setProperty/getProperty equivalents (the applicator
+   * uses foundry.utils directly — for this test we shim a tiny global).
+   */
+  const setupGlobalFoundryUtils = () => {
+    const getProperty = (obj, path) =>
+      path.split('.').reduce((o, k) => (o == null ? undefined : o[k]), obj);
+
+    const setProperty = (obj, path, value) => {
+      const keys = path.split('.');
+      let cur = obj;
+      for (let i = 0; i < keys.length - 1; i++) {
+        const k = keys[i];
+        if (cur[k] == null || typeof cur[k] !== 'object') cur[k] = {};
+        cur = cur[k];
+      }
+      cur[keys[keys.length - 1]] = value;
+      return true;
+    };
+
+    globalThis.foundry = {
+      ...(globalThis.foundry ?? {}),
+      utils: { ...(globalThis.foundry?.utils ?? {}), getProperty, setProperty }
+    };
+  };
+
+  beforeAll(setupGlobalFoundryUtils);
+
+  it('adds with legacy string mode (type: "add")', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 50 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      type: 'add',
+      value: '20'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(70);
+  });
+
+  it('adds with Foundry-standard numeric mode (CONST.ACTIVE_EFFECT_MODES.ADD = 2)', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 50 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      mode: 2, // CONST.ACTIVE_EFFECT_MODES.ADD
+      value: '20'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(70);
+  });
+
+  it('multiplies with Foundry-standard numeric mode (MULTIPLY = 1)', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 10 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      mode: 1, // CONST.ACTIVE_EFFECT_MODES.MULTIPLY
+      value: '3'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(30);
+  });
+
+  it('overrides with Foundry-standard numeric mode (OVERRIDE = 5)', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 50 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      mode: 5, // CONST.ACTIVE_EFFECT_MODES.OVERRIDE
+      value: '99'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(99);
+  });
+});
+
+describe('buildActiveEffectChangeOp writeKind', () => {
+  it('maps the legacy "override" string to overwrite', () => {
+    const op = buildActiveEffectChangeOp({ id: 'x', priority: 0 }, 0, {
+      key: 'system.combat.attack.final.value',
+      type: 'override',
+      value: '99'
+    });
+    expect(op.writes[0].kind).toBe('overwrite');
+  });
+
+  it('maps the Foundry-standard OVERRIDE numeric mode (5) to overwrite', () => {
+    const op = buildActiveEffectChangeOp({ id: 'x', priority: 0 }, 0, {
+      key: 'system.combat.attack.final.value',
+      mode: 5,
+      value: '99'
+    });
+    expect(op.writes[0].kind).toBe('overwrite');
+  });
+
+  it('maps any other mode to modify', () => {
+    const op = buildActiveEffectChangeOp({ id: 'x', priority: 0 }, 0, {
+      key: 'system.combat.attack.final.value',
+      mode: 2,
+      value: '20'
+    });
+    expect(op.writes[0].kind).toBe('modify');
+  });
+});

--- a/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
+++ b/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
@@ -191,3 +191,61 @@ describe('buildActiveEffectChangeOp writeKind', () => {
     expect(op.writes[0].kind).toBe('modify');
   });
 });
+
+/**
+ * Toggle on/off contract for the builder.
+ *
+ * Documents that the builder honours `effect.active` / `effect.disabled`
+ * correctly: an active effect produces ops, a disabled one produces none,
+ * and flipping the flag on the same actor flips the output.
+ *
+ * Note: the user-reported bug "uncheck the toggle, modifiers keep applying"
+ * was NOT here — it lived in `_getLinkedEffect` (compared item.uuid vs
+ * effect.origin and missed unlinked tokens, so the toggle never reached
+ * the AE). Fixed in findEffectLinkedToItem. These tests stay as a
+ * contract: if the builder ever stops respecting `disabled`, they catch it.
+ */
+describe('buildActiveEffectChangeOps — toggle off scenario', () => {
+  const ATTACK_PATH = 'system.combat.attack.final.value';
+
+  const makeEffect = ({ id, disabled }) => ({
+    id,
+    name: 'Sangre de Orochi',
+    disabled,
+    // Foundry's `effect.active` getter: !disabled && !suppressed
+    get active() {
+      return !this.disabled;
+    },
+    priority: 0,
+    changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }],
+    system: {}
+  });
+
+  it('emits one op when the effect is active (toggle ON)', () => {
+    const actor = { effects: { contents: [makeEffect({ id: 'eff1', disabled: false })] } };
+    const ops = buildActiveEffectChangeOps(actor);
+    expect(ops).toHaveLength(1);
+  });
+
+  it('emits zero ops when the effect is disabled (toggle OFF)', () => {
+    const actor = { effects: { contents: [makeEffect({ id: 'eff1', disabled: true })] } };
+    const ops = buildActiveEffectChangeOps(actor);
+    expect(ops).toHaveLength(0);
+  });
+
+  it('honours the live disabled flag — same actor, flipping the effect', () => {
+    const effect = makeEffect({ id: 'eff1', disabled: false });
+    const actor = { effects: { contents: [effect] } };
+
+    // Initially active
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(1);
+
+    // Simulate the toggle off (the sheet handler does effect.update({disabled: true}))
+    effect.disabled = true;
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(0);
+
+    // And back on
+    effect.disabled = false;
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(1);
+  });
+});

--- a/src/module/actor/utils/ensureLinkedEffectForItem.js
+++ b/src/module/actor/utils/ensureLinkedEffectForItem.js
@@ -1,0 +1,42 @@
+// /module/actor/utils/ensureLinkedEffectForItem.js
+import { findEffectLinkedToItem } from './findEffectLinkedToItem.js';
+
+/**
+ * Ensure the actor has an ActiveEffect document linked to the given system
+ * "effect" Item. If one already exists (matched via findEffectLinkedToItem)
+ * it is returned unchanged; otherwise a fresh AE is created from the item's
+ * `system.effectData` payload.
+ *
+ * Extracted from ABFActorSheet#_ensureEffectForItem so the same logic can be
+ * triggered from any flow that creates an effect Item on an actor (drop to
+ * a token, macro, programmatic creation), not just from a sheet drop.
+ *
+ * @param {object} actor  Foundry Actor (or token actor).
+ * @param {object} item   Foundry Item of type 'effect'.
+ * @returns {Promise<object|null>} The linked AE, or null on failure.
+ */
+export async function ensureLinkedEffectForItem(actor, item) {
+  if (!actor || !item) return null;
+
+  const existing = findEffectLinkedToItem(actor, item);
+  if (existing) return existing;
+
+  const rawBaseData = item.system?.effectData ?? {};
+  // Drop any stale origin baked into stored data; the new AE must point at
+  // the current item's uuid.
+  const { origin, ...baseData } = rawBaseData;
+
+  const data = foundry.utils.mergeObject(
+    {
+      name: item.name,
+      icon: item.img || 'icons/svg/aura.svg',
+      disabled: !item.system?.active,
+      origin: item.uuid
+    },
+    baseData,
+    { inplace: false }
+  );
+
+  const [created] = await actor.createEmbeddedDocuments('ActiveEffect', [data]);
+  return created ?? null;
+}

--- a/src/module/actor/utils/ensureLinkedEffectForItem.test.js
+++ b/src/module/actor/utils/ensureLinkedEffectForItem.test.js
@@ -1,0 +1,126 @@
+import { ensureLinkedEffectForItem } from './ensureLinkedEffectForItem.js';
+
+/**
+ * Behaviour contract for the helper that materializes an ActiveEffect
+ * document on the actor from a system "effect" Item. Used both from the
+ * sheet (_onDropItem) and from the global createItem hook so dropping an
+ * effect onto a token also creates the AE.
+ */
+
+const setupFoundryUtils = () => {
+  globalThis.foundry = {
+    ...(globalThis.foundry ?? {}),
+    utils: {
+      ...(globalThis.foundry?.utils ?? {}),
+      mergeObject: (a, b, _opts) => ({ ...a, ...b })
+    }
+  };
+};
+
+
+/** Tiny stand-in for jest.fn() — Jest 26 + experimental-vm-modules does not
+ *  always expose `jest` globally in ESM tests, so we roll our own minimal
+ *  spy with `.mock.calls` so the assertions below keep working. */
+function makeSpy(impl) {
+  const calls = [];
+  const fn = async (...args) => {
+    calls.push(args);
+    if (typeof impl === 'function') return impl(...args);
+    return undefined;
+  };
+  fn.mock = { calls };
+  return fn;
+}
+
+describe('ensureLinkedEffectForItem', () => {
+  beforeAll(setupFoundryUtils);
+
+  const makeItem = ({ id = 'I1', name = 'Sangre de Orochi', active = false, effectData = {} } = {}) => ({
+    _id: id,
+    id,
+    uuid: `Actor.A.Item.${id}`,
+    name,
+    img: 'icons/svg/aura.svg',
+    system: { active, effectData }
+  });
+
+  const makeActor = ({ effects = [], createSpy } = {}) => ({
+    effects: { contents: effects },
+    createEmbeddedDocuments: createSpy ?? makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }])
+  });
+
+  it('returns null when actor or item is missing', async () => {
+    expect(await ensureLinkedEffectForItem(null, makeItem())).toBeNull();
+    expect(await ensureLinkedEffectForItem(makeActor(), null)).toBeNull();
+  });
+
+  it('creates an AE on the actor when none is linked yet', async () => {
+    const item = makeItem({
+      effectData: {
+        changes: [{ key: 'system.combat.attack.final.value', value: '20', type: 'add' }]
+      }
+    });
+    const createSpy = makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }]);
+    const actor = makeActor({ createSpy });
+
+    const created = await ensureLinkedEffectForItem(actor, item);
+
+    expect(createSpy.mock.calls).toHaveLength(1);
+    expect(created.origin).toBe('Actor.A.Item.I1');
+    expect(created.disabled).toBe(true); // item.system.active = false
+    expect(created.name).toBe('Sangre de Orochi');
+    expect(created.changes).toEqual([
+      { key: 'system.combat.attack.final.value', value: '20', type: 'add' }
+    ]);
+  });
+
+  it('returns the existing AE without creating a duplicate', async () => {
+    const item = makeItem();
+    const existing = { id: 'AE1', origin: 'Actor.A.Item.I1' };
+    const createSpy = makeSpy();
+    const actor = makeActor({ effects: [existing], createSpy });
+
+    const result = await ensureLinkedEffectForItem(actor, item);
+
+    expect(result).toBe(existing);
+    expect(createSpy.mock.calls).toHaveLength(0);
+  });
+
+  it('finds the existing AE in unlinked tokens via the .Item.<id> tail', async () => {
+    // Token delta uuid form
+    const item = { _id: 'I1', id: 'I1', uuid: 'Scene.S.Token.T.Actor.A.Item.I1', name: 'X', img: '', system: { active: true, effectData: {} } };
+    const existing = { id: 'AE1', origin: 'Actor.A.Item.I1' }; // world-form origin
+    const createSpy = makeSpy();
+    const actor = makeActor({ effects: [existing], createSpy });
+
+    const result = await ensureLinkedEffectForItem(actor, item);
+
+    expect(result).toBe(existing);
+    expect(createSpy.mock.calls).toHaveLength(0);
+  });
+
+  it('respects active=true on the item (creates AE not disabled)', async () => {
+    const item = makeItem({ active: true });
+    const createSpy = makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }]);
+    const actor = makeActor({ createSpy });
+
+    const created = await ensureLinkedEffectForItem(actor, item);
+
+    expect(created.disabled).toBe(false);
+  });
+
+  it('strips any stale origin from item.system.effectData', async () => {
+    const item = makeItem({
+      effectData: {
+        origin: 'Actor.OLD.Item.OLD',
+        changes: []
+      }
+    });
+    const createSpy = makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }]);
+    const actor = makeActor({ createSpy });
+
+    const created = await ensureLinkedEffectForItem(actor, item);
+
+    expect(created.origin).toBe('Actor.A.Item.I1');
+  });
+});

--- a/src/module/actor/utils/findEffectLinkedToItem.js
+++ b/src/module/actor/utils/findEffectLinkedToItem.js
@@ -1,0 +1,34 @@
+// /module/actor/utils/findEffectLinkedToItem.js
+
+/**
+ * Find the ActiveEffect on `actor` that was created as the runtime mirror of
+ * `item` (a system "effect" Item).
+ *
+ * The natural matching key is `effect.origin === item.uuid`, but on unlinked
+ * tokens those two values diverge: the item lives in the TokenDocument delta
+ * and carries a UUID prefixed `Scene.<sceneId>.Token.<tokenId>.Actor.<id>.Item.<id>`,
+ * while the AE was created with `origin: item.uuid` at a moment where the
+ * uuid resolved to the world `Actor.<id>.Item.<id>` form. The trailing
+ * `.Item.<id>` segment is stable across both worlds and is what we match on
+ * as a fallback. This restores the link in unlinked tokens so toggle and
+ * delete actions can find and act on the corresponding AE.
+ *
+ * @param {object} actor
+ * @param {object} item
+ * @returns {object|null}
+ */
+export function findEffectLinkedToItem(actor, item) {
+  if (!actor || !item) return null;
+  const effects = actor.effects?.contents ?? actor.effects ?? [];
+  if (!effects.length) return null;
+
+  const directMatch = effects.find(e => e.origin === item.uuid);
+  if (directMatch) return directMatch;
+
+  const itemId = item._id ?? item.id;
+  if (!itemId) return null;
+  const tailMatch = effects.find(e =>
+    typeof e.origin === 'string' && e.origin.endsWith(`.Item.${itemId}`)
+  );
+  return tailMatch ?? null;
+}

--- a/src/module/actor/utils/findEffectLinkedToItem.test.js
+++ b/src/module/actor/utils/findEffectLinkedToItem.test.js
@@ -1,0 +1,68 @@
+import { findEffectLinkedToItem } from './findEffectLinkedToItem.js';
+
+/**
+ * Regression: in unlinked tokens, item.uuid carries a
+ * `Scene.<sceneId>.Token.<tokenId>.Actor.<id>.Item.<itemId>` prefix while
+ * the corresponding AE was created with `origin: item.uuid` resolved at a
+ * moment when it pointed to the world form `Actor.<id>.Item.<itemId>`. A
+ * direct string compare misses the link and the toggle / delete actions
+ * silently no-op against the AE. We match by the trailing `.Item.<itemId>`
+ * segment as a robust fallback.
+ */
+describe('findEffectLinkedToItem', () => {
+  it('returns null when actor or item is missing', () => {
+    expect(findEffectLinkedToItem(null, { uuid: 'x' })).toBeNull();
+    expect(findEffectLinkedToItem({ effects: { contents: [] } }, null)).toBeNull();
+  });
+
+  it('returns null when there are no effects on the actor', () => {
+    const actor = { effects: { contents: [] } };
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    expect(findEffectLinkedToItem(actor, item)).toBeNull();
+  });
+
+  it('matches by exact uuid (the common linked-actor case)', () => {
+    const effect = { origin: 'Actor.A.Item.I' };
+    const actor = { effects: { contents: [effect] } };
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    expect(findEffectLinkedToItem(actor, item)).toBe(effect);
+  });
+
+  it('matches by trailing .Item.<id> when prefixes diverge (unlinked token)', () => {
+    // Item lives in token delta: prefixed uuid.
+    const item = {
+      uuid: 'Scene.S.Token.T.Actor.A.Item.I',
+      _id: 'I'
+    };
+    // AE was created with origin pointing to the world form.
+    const effect = { origin: 'Actor.A.Item.I' };
+    const actor = { effects: { contents: [effect] } };
+
+    expect(findEffectLinkedToItem(actor, item)).toBe(effect);
+  });
+
+  it('does not match a different item id even if prefixes happen to share parts', () => {
+    const item = { uuid: 'Actor.A.Item.I1', _id: 'I1' };
+    const effect = { origin: 'Actor.A.Item.I2' };
+    const actor = { effects: { contents: [effect] } };
+
+    expect(findEffectLinkedToItem(actor, item)).toBeNull();
+  });
+
+  it('prefers the direct uuid match over the tail match when both exist', () => {
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    const direct = { origin: 'Actor.A.Item.I' };
+    const tail = { origin: 'Scene.S.Token.T.Actor.A.Item.I' };
+    const actor = { effects: { contents: [tail, direct] } };
+
+    expect(findEffectLinkedToItem(actor, item)).toBe(direct);
+  });
+
+  it('handles the actor.effects shape both as Foundry collection and as plain array', () => {
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    const effect = { origin: 'Actor.A.Item.I' };
+
+    expect(findEffectLinkedToItem({ effects: { contents: [effect] } }, item)).toBe(effect);
+    expect(findEffectLinkedToItem({ effects: [effect] }, item)).toBe(effect);
+  });
+});

--- a/src/module/dialogs/AttackConfigurationDialog.js
+++ b/src/module/dialogs/AttackConfigurationDialog.js
@@ -2,6 +2,8 @@ import { Templates } from '../utils/constants';
 import { ABFConfig } from '../ABFConfig';
 import { ABFAttackData } from '../combat/ABFAttackData';
 import { getSnapshotTargets } from '../actor/utils/getSnapshotTargets.js';
+import { getActiveEffectsBreakdownForPath } from '../actor/utils/activeEffectsBreakdown.js';
+import { formatAeBreakdownForFlavor } from '../actor/utils/aeBreakdownFormat.js';
 ///dialogs/AttackConfigurationDialog.js
 ///actor/utils/getSnapshotTargets.js
 
@@ -162,7 +164,25 @@ export class AttackConfigurationDialog extends FormApplication {
           ? actor.system.general.diceSettings.abilityMasteryDie.value
           : actor.system.general.diceSettings.abilityDie.value;
 
-      const formula = `${die} + ${baseAttack} + ${mod}`;
+      // --- Traceability of Active Effects ----------------------------------
+      // Active Effects (Sangre de Orochi, Cegueras, Derribado...) write to
+      // actor.system.combat.attack.final.value. The weapon's attack.final
+      // already inherits that via calculateWeaponAttack, so the AE delta is
+      // fused inside baseAttack. To restore traceability we split it back
+      // out into its own term in the formula (only when every AE is a
+      // linear add — for multiply/override we leave the formula fused and
+      // just expose the nominal list in the flavor).
+      const aeBreakdown = getActiveEffectsBreakdownForPath(
+        actor,
+        'system.combat.attack.final.value'
+      );
+      const aeContribution = aeBreakdown.hasNonLinear ? 0 : aeBreakdown.linearTotal;
+      const attackPure = baseAttack - aeContribution;
+
+      const formula = aeContribution !== 0
+        ? `${die} + ${attackPure} + ${aeContribution} + ${mod}`
+        : `${die} + ${baseAttack} + ${mod}`;
+
       const roll = new ABFFoundryRoll(formula, actor.system);
       await roll.evaluate({ async: true });
 
@@ -175,9 +195,14 @@ export class AttackConfigurationDialog extends FormApplication {
         ? { ...ChatMessage.getSpeaker({ token: tokenForSpeaker }), alias: tokenName }
         : ChatMessage.getSpeaker({ actor });
 
+      const baseFlavor = 'Rolling attack';
+      const flavor = aeBreakdown.items.length > 0
+        ? `${baseFlavor}${formatAeBreakdownForFlavor(aeBreakdown)}`
+        : baseFlavor;
+
       await roll.toMessage({
         speaker,
-        flavor: 'Rolling attack'
+        flavor
       });
 
       const attackData = ABFAttackData.builder()

--- a/src/module/dialogs/DefenseConfigurationDialog.js
+++ b/src/module/dialogs/DefenseConfigurationDialog.js
@@ -7,6 +7,7 @@ import { updateAttackTargetsFlag } from '../../utils/updateAttackTargetsFlag.js'
 import { getChatVisibilityOptions } from '../utils/chatVisibility.js';
 import ABFFoundryRoll from '../rolls/ABFFoundryRoll.js';
 import { FormulaEvaluator } from '../../utils/formulaEvaluator.js';
+import { defensesCounterCheck } from '../combat/utils/defensesCounterCheck.js';
 
 export class DefenseConfigurationDialog extends FormApplication {
   constructor(object = {}, options = {}) {
@@ -54,6 +55,14 @@ export class DefenseConfigurationDialog extends FormApplication {
 
     const defenderActor = defender.actor;
 
+    // Read defenses counter flag from defender actor. Same source-of-truth used by
+    // CombatDefenseDialog so both flows stay consistent when the actor accumulates
+    // defenses during a round (reset is handled by ABFCombat hooks on turn change).
+    const defensesCounter = defenderActor.getFlag?.(game.animabf.id, 'defensesCounter') || {
+      accumulated: 0,
+      keepAccumulating: true
+    };
+
     const weapons = defenderActor.system?.combat?.weapons ?? [];
     const firstWeapon = weapons[0];
 
@@ -93,7 +102,12 @@ export class DefenseConfigurationDialog extends FormApplication {
         combat: {
           modifier: 0,
           fatigueUsed: 0,
-          multipleDefensesPenalty: 0,
+          // Auto-derive the multiple-defenses penalty from the actor's running counter.
+          // No manual UI override is exposed in this dialog by design: the penalty
+          // is fully driven by the rules (counter -> defensesCounterCheck mapping)
+          // and the dialog only shows the resulting value as a read-only label.
+          multipleDefensesPenalty: defensesCounterCheck(defensesCounter.accumulated),
+          accumulateDefenses: defensesCounter.keepAccumulating,
 
           weaponUsed: initialWeaponUsed,
           weapon: initialWeapon,
@@ -332,10 +346,18 @@ export class DefenseConfigurationDialog extends FormApplication {
 
       const mod = Number(combat?.modifier ?? 0);
       const multiPenalty = Number(combat?.multipleDefensesPenalty ?? 0);
+      const baseValue = Number(defenseAbility.finalBase ?? 0);
 
-      const formula = `${die} + ${
-        Number(defenseAbility.finalBase ?? 0) + mod + multiPenalty
-      }`;
+      // Defense-type specific rules (mirrors RULES in DefenseStrategies.js):
+      // supernatural shields neither apply the multiple-defenses penalty nor
+      // stack into the defenses counter. Block and dodge do both.
+      const isShieldDefense = type === 'shield';
+      const effectiveMultiPenalty = isShieldDefense ? 0 : multiPenalty;
+
+      // Split each contribution into its own term so the Foundry roll tooltip
+      // shows the breakdown: defense ability, situational modifier, and the
+      // multiple-defenses penalty as three traceable parts.
+      const formula = `${die} + ${baseValue} + ${mod} + (${effectiveMultiPenalty})`;
       const roll = new ABFFoundryRoll(formula, actor.system);
       await roll.evaluate({ async: true });
 
@@ -348,9 +370,13 @@ export class DefenseConfigurationDialog extends FormApplication {
         ? { ...ChatMessage.getSpeaker({ token: tokenForSpeaker }), alias: tokenName }
         : ChatMessage.getSpeaker({ actor });
 
+      const defenseLabel = game.i18n.localize(
+        'macros.combat.dialog.defending.defend.title'
+      );
+
       await roll.toMessage({
         speaker,
-        flavor: 'Rolling defense',
+        flavor: defenseLabel,
         rollMode: vis.rollMode
       });
 
@@ -417,6 +443,15 @@ export class DefenseConfigurationDialog extends FormApplication {
         defenseResult: defenseData.toJSON?.() ?? defenseData,
         updatedAt: Date.now()
       });
+
+      // Increment the defender's defenses counter so the next defense in this
+      // round gets the right multi-defense penalty. The actor method respects
+      // the `keepAccumulating` flag; ABFCombat hooks reset the counter when
+      // the round changes. Supernatural-shield defenses do NOT stack (mirrors
+      // RULES.supernaturalShield.stackDefense in DefenseStrategies.js).
+      if (!isShieldDefense && typeof actor?.accumulateDefenses === 'function') {
+        actor.accumulateDefenses(!!combat?.accumulateDefenses);
+      }
 
       await this.close();
     } catch (err) {

--- a/src/module/dialogs/combat/CombatAttackDialog.js
+++ b/src/module/dialogs/combat/CombatAttackDialog.js
@@ -4,6 +4,8 @@ import { damageCheck } from '../../combat/utils/damageCheck.js';
 import ABFFoundryRoll from '../../rolls/ABFFoundryRoll';
 import { ABFSettingsKeys } from '../../../utils/registerSettings';
 import { ABFConfig } from '../../ABFConfig';
+import { getActiveEffectsBreakdownForPath } from '../../actor/utils/activeEffectsBreakdown.js';
+import { formatAeBreakdownForFlavor } from '../../actor/utils/aeBreakdownFormat.js';
 
 const getInitialData = (attacker, defender, options = {}) => {
   const combatDistance = !!game.settings.get(
@@ -365,8 +367,33 @@ export class CombatAttackDialog extends FormApplication {
         for (const key in attackerCombatMod)
           combatModifier += attackerCombatMod[key]?.value ?? 0;
 
+        // --- Traceability of Active Effects -------------------------------
+        // Active Effects (Sangre de Orochi, Cegueras, Derribado...) write to
+        // system.combat.attack.final.value directly. When we use that value
+        // in the roll formula their contribution disappears into the total,
+        // losing the breakdown the GM needs to audit a roll.
+        //
+        // To restore traceability we ask the helper how much of the current
+        // attack value comes from AE, and when every AE is a linear `add`
+        // we expose it as its own term in the formula:
+        //   baseDice + counterAttack + attackPure + aeContribution + combatModifier
+        // (with weapon: attackPure = weapon.attack.final - aeContribution,
+        //  because the weapon final already inherits the actor AE.)
+        //
+        // If any AE is multiply/override we keep the formula fused (the
+        // contribution is not a single linear delta we can split safely)
+        // and only expose the nominal list to the chat template.
+        const aeBreakdown = getActiveEffectsBreakdownForPath(
+          this.attackerActor,
+          'system.combat.attack.final.value'
+        );
+        const aeContribution = aeBreakdown.hasNonLinear ? 0 : aeBreakdown.linearTotal;
+        const attackPure = attack - aeContribution;
+
         const baseDice = this.getBaseCombatDiceFormula(this.attackerActor);
-        let formula = `${baseDice} + ${counterAttackBonus} + ${attack} + ${combatModifier}`;
+        let formula = aeContribution !== 0
+          ? `${baseDice} + ${counterAttackBonus} + ${attackPure} + ${aeContribution} + ${combatModifier}`
+          : `${baseDice} + ${counterAttackBonus} + ${attack} + ${combatModifier}`;
 
         if (this.modalData.attacker.withoutRoll) {
           formula = this.removeFirstDiceTerm(formula);
@@ -381,7 +408,7 @@ export class CombatAttackDialog extends FormApplication {
 
         if (this.modalData.attacker.showRoll) {
           const { i18n } = game;
-          const flavor = weapon
+          const baseFlavor = weapon
             ? i18n.format('macros.combat.dialog.physicalAttack.title', {
                 weapon: weapon?.name,
                 target: this.modalData.defender.token.name
@@ -389,6 +416,13 @@ export class CombatAttackDialog extends FormApplication {
             : i18n.format('macros.combat.dialog.physicalAttack.unarmed.title', {
                 target: this.modalData.defender.token.name
               });
+
+          // Append a nominal breakdown of the AE that contributed to the roll
+          // so the GM can audit which effect added or subtracted what,
+          // without having to inspect the actor.
+          const flavor = aeBreakdown.items.length > 0
+            ? `${baseFlavor}${formatAeBreakdownForFlavor(aeBreakdown)}`
+            : baseFlavor;
 
           roll.toMessage({
             speaker: ChatMessage.getSpeaker({ token: this.modalData.attacker.token }),
@@ -432,7 +466,8 @@ export class CombatAttackDialog extends FormApplication {
             projectile,
             attackerCombatMod,
             critDamageBonus: critDamageBonus ?? 0,
-            automaticCrit: !!automaticCrit
+            automaticCrit: !!automaticCrit,
+            activeEffectsBreakdown: aeBreakdown
           }
         });
 
@@ -536,7 +571,8 @@ export class CombatAttackDialog extends FormApplication {
             macro: spell.macro,
             attackerCombatMod,
             critDamageBonus: critDamageBonus ?? 0,
-            automaticCrit: !!automaticCrit
+            automaticCrit: !!automaticCrit,
+            activeEffectsBreakdown: aeBreakdown
           }
         });
 
@@ -655,7 +691,8 @@ export class CombatAttackDialog extends FormApplication {
             macro: power.macro,
             attackerCombatMod,
             critDamageBonus: critDamageBonus ?? 0,
-            automaticCrit: !!automaticCrit
+            automaticCrit: !!automaticCrit,
+            activeEffectsBreakdown: aeBreakdown
           }
         });
 

--- a/src/module/types/effects/EffectItemConfig.js
+++ b/src/module/types/effects/EffectItemConfig.js
@@ -2,6 +2,7 @@
 import { ABFItems } from '../../items/ABFItems';
 import { openSimpleInputDialog } from '../../utils/dialogs/openSimpleInputDialog';
 import { ABFItemConfigFactory } from '../ABFItemConfig';
+import { findEffectLinkedToItem } from '../../actor/utils/findEffectLinkedToItem.js';
 
 export const INITIAL_EFFECT_DATA = {
   active: false,
@@ -75,7 +76,7 @@ export const EffectItemConfig = ABFItemConfigFactory({
     // is high during play. So this onDelete intentionally skips the
     // ABFDialogs.confirm step that the generic delete flow uses for items
     // whose loss is harder to recover (weapons with computed bonuses, etc.).
-    const effect = actor.effects.find(e => e.origin === item.uuid) ?? null;
+    const effect = findEffectLinkedToItem(actor, item);
 
     const ops = [];
     if (effect) {

--- a/src/module/types/effects/EffectItemConfig.js
+++ b/src/module/types/effects/EffectItemConfig.js
@@ -2,7 +2,6 @@
 import { ABFItems } from '../../items/ABFItems';
 import { openSimpleInputDialog } from '../../utils/dialogs/openSimpleInputDialog';
 import { ABFItemConfigFactory } from '../ABFItemConfig';
-import { ABFDialogs } from '../../dialogs/ABFDialogs';
 
 export const INITIAL_EFFECT_DATA = {
   active: false,
@@ -56,29 +55,35 @@ export const EffectItemConfig = ABFItemConfigFactory({
   },
 
   onDelete: async (actor, target) => {
-    const id = target[0]?.dataset?.itemId;
+    // Foundry exposes the ContextMenu callback target as either a jQuery
+    // selector (legacy V13 behaviour) or a raw HTMLElement (V14, also seen
+    // in V13 when foundry.applications.ux.ContextMenu.implementation is
+    // available). Normalize both shapes; previously `target[0]?.dataset`
+    // would silently return undefined under the HTMLElement shape and the
+    // delete action did nothing.
+    const el = target instanceof HTMLElement ? target : target?.[0];
+    const id = el?.dataset?.itemId;
     if (!id) return;
 
     const item = actor.items.get(id);
     if (!item) return;
 
-    ABFDialogs.confirm(
-      game.i18n.localize('dialogs.items.delete.title'),
-      game.i18n.localize('dialogs.items.delete.body'),
-      {
-        onConfirm: async () => {
-          const effect = actor.effects.find(e => e.origin === item.uuid) ?? null;
+    // Effects are transient combat states (Sorpresa, Derribado, Cegueras,
+    // Paralisis...) that the GM toggles on and off many times per fight.
+    // The cost of an accidental delete is low (re-drag from the compendium
+    // takes one drag) and the cost of an extra confirmation dialog per click
+    // is high during play. So this onDelete intentionally skips the
+    // ABFDialogs.confirm step that the generic delete flow uses for items
+    // whose loss is harder to recover (weapons with computed bonuses, etc.).
+    const effect = actor.effects.find(e => e.origin === item.uuid) ?? null;
 
-          const ops = [];
-          if (effect) {
-            ops.push(actor.deleteEmbeddedDocuments('ActiveEffect', [effect.id]));
-          }
-          ops.push(actor.deleteEmbeddedDocuments('Item', [id]));
+    const ops = [];
+    if (effect) {
+      ops.push(actor.deleteEmbeddedDocuments('ActiveEffect', [effect.id]));
+    }
+    ops.push(actor.deleteEmbeddedDocuments('Item', [id]));
 
-          await Promise.all(ops);
-        }
-      }
-    );
+    await Promise.all(ops);
   },
 
   onAttach: async () => {},

--- a/src/module/types/general/ElanPowerItemConfig.js
+++ b/src/module/types/general/ElanPowerItemConfig.js
@@ -106,13 +106,18 @@ export const ElanPowerItemConfig = ABFItemConfigFactory({
     }
   },
   onDelete: async (actor, target) => {
-    const { elanId } = target[0].dataset;
+    // Normalize the ContextMenu target shape: jQuery selector (legacy V13)
+    // vs HTMLElement (V14, and V13 when the new ContextMenu implementation
+    // is available). Without this, the V14 path would throw because
+    // `target[0]` is undefined for HTMLElement.
+    const el = target instanceof HTMLElement ? target : target?.[0];
+    const { elanId } = el?.dataset ?? {};
 
     if (!elanId) {
       throw new Error('Data id missing. Are you sure to set data-elan-id to rows?');
     }
 
-    const { elanPowerId } = target[0].dataset;
+    const { elanPowerId } = el.dataset;
 
     if (!elanPowerId) {
       throw new Error('Data id missing. Are you sure to set data-elan-power-id to rows?');

--- a/src/templates/dialog/combat/defense-config-dialog.hbs
+++ b/src/templates/dialog/combat/defense-config-dialog.hbs
@@ -15,6 +15,24 @@
         inputValue=this.defender.combat.modifier
       }}
 
+      {{#if (is 'eq' this.ui.activeTab 'shield')}}
+        <p class="label defense-count">
+          {{localize 'macros.combat.dialog.defenseCount.exemption.supernaturalShield'}}
+        </p>
+      {{else}}
+        <p class="label defense-count">
+          {{localize 'macros.combat.dialog.defenseCount.title'}}: {{this.defender.combat.multipleDefensesPenalty}}
+        </p>
+      {{/if}}
+
+      {{>
+        "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
+        title=(localize 'macros.combat.dialog.combat.accumulateDefenses.title')
+        inputType="checkbox"
+        inputName="defender.combat.accumulateDefenses"
+        inputValue=(is 'eq' this.defender.combat.accumulateDefenses true)
+      }}
+
       <nav class="animabf-tabs sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="dodge">{{localize "macros.combat.dialog.dodgeButton.title"}}</a>
         <a class="item" data-tab="block">{{localize "macros.combat.dialog.blockButton.title"}}</a>

--- a/src/utils/chatActionHandlers/defendActionHandler.js
+++ b/src/utils/chatActionHandlers/defendActionHandler.js
@@ -61,7 +61,11 @@ export default async function defendActionHandler(message, _html, dataset) {
 
     const defenseMode =
       defenderToken.actor?.system?.general?.settings?.defenseType?.value;
-    if (defenseMode === 'resistance') {
+    // Both 'resistance' (damage-resistance defenders) and 'mass' (mass-of-enemies
+    // rule defenders) skip the regular defense dialog: no roll, no multi-defense
+    // counter increment, armor still applies. They funnel through the zero-roll
+    // defense helper instead.
+    if (defenseMode === 'resistance' || defenseMode === 'mass') {
       await sendAccumulationZeroDefense({
         defenderToken,
         attackerToken,

--- a/src/utils/chatActionHandlers/defendTargetActionHandler.js
+++ b/src/utils/chatActionHandlers/defendTargetActionHandler.js
@@ -78,7 +78,11 @@ async function defendTargetActionHandler(message, _html, dataset) {
     // Use the stored token key when present, so the flag update hits the correct entry
     const storedTokenKey = targetEntry?.tokenUuid ?? '';
 
-    if (defenseMode === 'resistance') {
+    // Both 'resistance' (damage-resistance defenders) and 'mass' (mass-of-enemies
+    // rule defenders) skip the regular defense dialog: no roll, no multi-defense
+    // counter increment, armor still applies. They funnel through the zero-roll
+    // defense helper instead.
+    if (defenseMode === 'resistance' || defenseMode === 'mass') {
       await sendAccumulationZeroDefense({
         defenderToken,
         attackerToken,


### PR DESCRIPTION
- Las defensas adicionales aplican su penalizador acumulativo en el
  diálogo de defensa de manera automatica

- Se quita el diálogo de confirmación porque los effects son
  estados transitorios que se quitan y ponen muchas veces en combate.

- Al tirar un ataque, el chat muestra de dónde viene cada bono:
  `dado + 105 + 20 + 0` en la fórmula y "Mod: Sangre de Orochi (+20)"
  en el flavor. Si hay varios AE activos, los lista todos.

- Desactivar un effect con el checkbox de la ficha lo apaga al
  instante incluso en tokens no enlazados (antes se quedaba aplicado
  hasta recargar).

- Arrastrar un effect funciona desde cualquier sitio:
  - Al token en el mapa.
  - A la fila del actor en el sidebar
  - A la pestaña de efectos en la ficha (como antes).
  - Desde macros o creación programática.

Incluye 28 tests unitarios nuevos (Jest) cubriendo los cambios.