### PR TITLE
fix(effects): Información en los cuadros de texto sobre los Active Effects que están aplicando y automatización en pen. de defensas adicionales 

### DIFF
--- a/src/animabf.mjs
+++ b/src/animabf.mjs
@@ -33,6 +33,7 @@ import { FormulaEvaluator } from './utils/formulaEvaluator.js';
 import { registerHandlebarsPartials } from './utils/handlebarsPartials.js';
 
 import { macroCreators, macroExecutors } from './utils/macroCreatorRegistry.js';
+import { ensureLinkedEffectForItem } from './module/actor/utils/ensureLinkedEffectForItem.js';
 
 /* ------------------------------------ */
 /* Initialize system */
@@ -338,6 +339,45 @@ Hooks.on('chatMessage', (chatLog, message, chatData) => {
   chatData._animabfFormulaDone = true;
   chatLog.processMessage(replaced, chatData);
   return false;
+});
+
+// When a system "effect" Item is created on an actor (drop to a token,
+// macro, programmatic), make sure the matching ActiveEffect document also
+// exists on the actor. Previously this only happened from the sheet's
+// _onDropItem, so dropping an effect onto a token never created the AE and
+// the modifiers were never applied until the user re-dragged through the
+// sheet.
+Hooks.on('createItem', async (item, _options, userId) => {
+  if (userId !== game.user.id) return;
+  if (item?.type !== 'effect') return;
+  const actor = item.parent;
+  if (!actor) return;
+  await ensureLinkedEffectForItem(actor, item);
+});
+
+// Allow dropping system "effect" items directly onto a token on the canvas.
+// Foundry V13 does not route this drop into the token's actor by default for
+// our effect type, so the item never reaches the sheet's _onDropItem flow.
+// We intercept the canvas drop, resolve the token under the cursor and
+// create the item ourselves; the createItem hook above then materializes the
+// linked ActiveEffect.
+Hooks.on('dropCanvasData', async (canvas, data) => {
+  if (data?.type !== 'Item' || !data.uuid) return;
+
+  const droppedItem = await fromUuid(data.uuid);
+  if (!droppedItem || droppedItem.type !== 'effect') return;
+
+  const gridSize = canvas.grid?.size ?? 100;
+  const hit = canvas.tokens?.placeables?.find(t => {
+    const w = (t.document?.width ?? 1) * gridSize;
+    const h = (t.document?.height ?? 1) * gridSize;
+    return data.x >= t.x && data.x <= t.x + w &&
+           data.y >= t.y && data.y <= t.y + h;
+  });
+  if (!hit?.actor) return;
+
+  await hit.actor.createEmbeddedDocuments('Item', [droppedItem.toObject()]);
+  return false; // Prevent the default drop handling
 });
 
 Hooks.on('renderActiveEffectConfig', (app, html) => {

--- a/src/animabf.mjs
+++ b/src/animabf.mjs
@@ -34,6 +34,9 @@ import { registerHandlebarsPartials } from './utils/handlebarsPartials.js';
 
 import { macroCreators, macroExecutors } from './utils/macroCreatorRegistry.js';
 import { ensureLinkedEffectForItem } from './module/actor/utils/ensureLinkedEffectForItem.js';
+import { inferAttributeFromFlavor } from './module/actor/utils/attributeDerivationMap.js';
+import { getActiveEffectsBreakdownForAttribute } from './module/actor/utils/activeEffectsBreakdown.js';
+import { formatAeBreakdownForFlavor } from './module/actor/utils/aeBreakdownFormat.js';
 
 /* ------------------------------------ */
 /* Initialize system */
@@ -378,6 +381,52 @@ Hooks.on('dropCanvasData', async (canvas, data) => {
 
   await hit.actor.createEmbeddedDocuments('Item', [droppedItem.toObject()]);
   return false; // Prevent the default drop handling
+});
+
+// Universal trace: any roll-bearing chat message that comes from an actor
+// of this system gets a breakdown of the Active Effects that contributed to
+// the rolled attribute (Sangre de Orochi (+20), Ceguera parcial (-30), ...).
+// Identifies the attribute from the roll's flavor text. Single touchpoint,
+// covers all dialogs and macro-driven rolls without needing per-site wiring.
+Hooks.on('preCreateChatMessage', (message, data, _options, _userId) => {
+  try {
+    if (!Array.isArray(data?.rolls) && !data?.roll) return;
+
+    const speaker = data.speaker ?? message.speaker;
+    if (!speaker) return;
+
+    // Resolve the actor that owns the token/speaker so AE on unlinked
+    // tokens are read from the token actor (not the world actor).
+    let actor = null;
+    if (speaker.token) {
+      try {
+        const sceneId = speaker.scene;
+        const tokenDoc = sceneId
+          ? game.scenes?.get(sceneId)?.tokens?.get?.(speaker.token)
+          : null;
+        actor = tokenDoc?.actor ?? null;
+      } catch {}
+    }
+    if (!actor && speaker.actor) {
+      actor = game.actors?.get(speaker.actor) ?? null;
+    }
+    if (!actor) return;
+
+    const flavor = data.flavor ?? message.flavor ?? '';
+    const attribute = inferAttributeFromFlavor(flavor);
+    if (!attribute) return;
+
+    const breakdown = getActiveEffectsBreakdownForAttribute(actor, attribute);
+    if (!breakdown.items.length) return;
+
+    const suffix = formatAeBreakdownForFlavor(breakdown);
+    if (!suffix) return;
+    if (typeof flavor === 'string' && flavor.includes('<small><em>Mod')) return;
+
+    message.updateSource({ flavor: `${flavor}${suffix}` });
+  } catch (err) {
+    console.warn('animabf: failed to enrich roll flavor with AE breakdown', err);
+  }
 });
 
 Hooks.on('renderActiveEffectConfig', (app, html) => {

--- a/src/animabf.mjs
+++ b/src/animabf.mjs
@@ -37,6 +37,7 @@ import { ensureLinkedEffectForItem } from './module/actor/utils/ensureLinkedEffe
 import { inferAttributeFromFlavor } from './module/actor/utils/attributeDerivationMap.js';
 import { getActiveEffectsBreakdownForAttribute } from './module/actor/utils/activeEffectsBreakdown.js';
 import { formatAeBreakdownForFlavor } from './module/actor/utils/aeBreakdownFormat.js';
+import { resolveActorFromSpeaker } from './module/actor/utils/resolveActorForRoll.js';
 
 /* ------------------------------------ */
 /* Initialize system */
@@ -395,21 +396,9 @@ Hooks.on('preCreateChatMessage', (message, data, _options, _userId) => {
     const speaker = data.speaker ?? message.speaker;
     if (!speaker) return;
 
-    // Resolve the actor that owns the token/speaker so AE on unlinked
-    // tokens are read from the token actor (not the world actor).
-    let actor = null;
-    if (speaker.token) {
-      try {
-        const sceneId = speaker.scene;
-        const tokenDoc = sceneId
-          ? game.scenes?.get(sceneId)?.tokens?.get?.(speaker.token)
-          : null;
-        actor = tokenDoc?.actor ?? null;
-      } catch {}
-    }
-    if (!actor && speaker.actor) {
-      actor = game.actors?.get(speaker.actor) ?? null;
-    }
+    // Use the single resolver to make sure dialog and hook see the same
+    // actor (the TokenActor with ActorDelta for unlinked tokens).
+    const actor = resolveActorFromSpeaker(speaker);
     if (!actor) return;
 
     const flavor = data.flavor ?? message.flavor ?? '';

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -727,6 +727,7 @@
   "macros.combat.dialog.defense.title": "Defense",
   "macros.combat.dialog.defenseButton.title": "Send defense",
   "macros.combat.dialog.defenseCount.title": "Defense penalty",
+  "macros.combat.dialog.defenseCount.exemption.supernaturalShield": "Supernatural shields do not apply the multiple-defenses penalty",
   "macros.combat.dialog.defenseSent.title": "Defense sent. Waiting for combat results...",
   "macros.combat.dialog.defenseType.block.title": "Block",
   "macros.combat.dialog.defenseType.dodge.title": "Dodge",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -727,6 +727,7 @@
   "macros.combat.dialog.defense.title": "Defensa",
   "macros.combat.dialog.defenseButton.title": "Enviar defensa",
   "macros.combat.dialog.defenseCount.title": "Penalizador por defensa continua",
+  "macros.combat.dialog.defenseCount.exemption.supernaturalShield": "Los escudos sobrenaturales no aplican penalizador por defensa continua",
   "macros.combat.dialog.defenseSent.title": "Defensa enviada. Esperando a los resultados del combate...",
   "macros.combat.dialog.defenseType.block.title": "Bloqueo",
   "macros.combat.dialog.defenseType.dodge.title": "Esquiva",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -656,6 +656,7 @@
   "macros.combat.dialog.defense.title": "Défense",
   "macros.combat.dialog.defenseButton.title": "Envoyer la défense",
   "macros.combat.dialog.defenseCount.title": "Malus de Défense",
+  "macros.combat.dialog.defenseCount.exemption.supernaturalShield": "Les boucliers surnaturels n'appliquent pas le malus de défense multiple",
   "macros.combat.dialog.defenseSent.title": "Défense envoyée. Attente des résultats du combat...",
   "macros.combat.dialog.defenseType.block.title": "Parade",
   "macros.combat.dialog.defenseType.dodge.title": "Esquive",

--- a/src/module/SidebarDirectories/ABFActorDirectory.js
+++ b/src/module/SidebarDirectories/ABFActorDirectory.js
@@ -30,6 +30,44 @@ export default class ABFActorDirectory extends ActorDirectoryV1 {
   }
 
   /**
+   * Intercept drops over an actor row in the sidebar so dragging a system
+   * "effect" Item onto an actor in the directory creates the Item on that
+   * actor (Foundry V13 does not route this drop by default). Once the Item
+   * exists, the global createItem hook materializes the linked ActiveEffect,
+   * matching the behaviour of drops over a token on the canvas and drops
+   * over an open sheet.
+   *
+   * @param {DragEvent} event
+   */
+  async _onDrop(event) {
+    let data;
+    try {
+      const TE = foundry.applications?.ux?.TextEditor?.implementation ?? TextEditor;
+      data = typeof TE?.getDragEventData === 'function'
+        ? TE.getDragEventData(event)
+        : JSON.parse(event.dataTransfer.getData('text/plain'));
+    } catch {
+      data = null;
+    }
+
+    if (data?.type === 'Item' && data.uuid) {
+      const row = event.target?.closest?.('[data-entry-id], [data-document-id]');
+      const actorId = row?.dataset?.entryId ?? row?.dataset?.documentId;
+      const actor = actorId ? game.actors.get(actorId) : null;
+
+      if (actor) {
+        const item = await fromUuid(data.uuid);
+        if (item?.type === 'effect') {
+          await actor.createEmbeddedDocuments('Item', [item.toObject()]);
+          return;
+        }
+      }
+    }
+
+    return super._onDrop?.(event);
+  }
+
+  /**
    * Muestra el diálogo para importar desde Excel
    * @param {Actor} document
    * @returns {Promise<void>}

--- a/src/module/actor/ABFActorSheet.js
+++ b/src/module/actor/ABFActorSheet.js
@@ -13,6 +13,7 @@ import { ABFSettingsKeys } from '../../utils/registerSettings';
 import { createClickHandlers } from './utils/createClickHandlers';
 import { TypeEditorRegistry } from './types/TypeEditorRegistry.js';
 import { findEffectLinkedToItem } from './utils/findEffectLinkedToItem.js';
+import { ensureLinkedEffectForItem } from './utils/ensureLinkedEffectForItem.js';
 
 /** @typedef {import('./constants').TActorData} TData */
 /** @typedef {typeof FormApplication<FormApplicationOptions, TData, TData>} TFormApplication */
@@ -616,28 +617,7 @@ export default class ABFActorSheet extends ActorSheetV1 {
   }
 
   async _ensureEffectForItem(item) {
-    if (!item) return null;
-
-    const effect = this._getLinkedEffect(item);
-    if (effect) return effect;
-
-    const rawBaseData = item.system?.effectData ?? {};
-    // Ignore old origin if it exists in stored data
-    const { origin, ...baseData } = rawBaseData;
-
-    const data = foundry.utils.mergeObject(
-      {
-        name: item.name,
-        icon: item.img || 'icons/svg/aura.svg',
-        disabled: !item.system?.active,
-        origin: item.uuid // always the current item
-      },
-      baseData,
-      { inplace: false }
-    );
-
-    const [created] = await this.actor.createEmbeddedDocuments('ActiveEffect', [data]);
-    return created ?? null;
+    return ensureLinkedEffectForItem(this.actor, item);
   }
 
   async _onDropItem(event, data) {

--- a/src/module/actor/ABFActorSheet.js
+++ b/src/module/actor/ABFActorSheet.js
@@ -12,6 +12,7 @@ import { Logger } from '../../utils';
 import { ABFSettingsKeys } from '../../utils/registerSettings';
 import { createClickHandlers } from './utils/createClickHandlers';
 import { TypeEditorRegistry } from './types/TypeEditorRegistry.js';
+import { findEffectLinkedToItem } from './utils/findEffectLinkedToItem.js';
 
 /** @typedef {import('./constants').TActorData} TData */
 /** @typedef {typeof FormApplication<FormApplicationOptions, TData, TData>} TFormApplication */
@@ -606,7 +607,7 @@ export default class ABFActorSheet extends ActorSheetV1 {
 
   _getLinkedEffect(item) {
     if (!item) return null;
-    return this.actor.effects.find(e => e.origin === item.uuid) ?? null;
+    return findEffectLinkedToItem(this.actor, item);
   }
 
   async _linkItemToEffect(item, effect) {

--- a/src/module/actor/utils/activeEffectsBreakdown.js
+++ b/src/module/actor/utils/activeEffectsBreakdown.js
@@ -1,0 +1,108 @@
+// /module/actor/utils/activeEffectsBreakdown.js
+
+/**
+ * Normalize an Active Effect change to a logical mode string.
+ * Kept in sync with the resolver in activeEffectApplicator.js — we cannot
+ * import from inside the effectFow folder here because this helper is
+ * consumed from UI/dialog code that should not depend on the full effect
+ * flow machinery.
+ */
+function normalizeChangeMode(change) {
+  if (typeof change?.type === 'string') return change.type;
+  switch (change?.mode) {
+    case 1: return 'multiply';
+    case 2: return 'add';
+    case 3: return 'override'; // DOWNGRADE -> treated as override
+    case 4: return 'override'; // UPGRADE   -> treated as override
+    case 5: return 'override';
+    default: return 'add';
+  }
+}
+
+function getProp(obj, path) {
+  if (!obj || !path) return undefined;
+  const keys = path.split('.');
+  let cur = obj;
+  for (const k of keys) {
+    if (cur == null) return undefined;
+    cur = cur[k];
+  }
+  return cur;
+}
+
+/**
+ * Inspect the active Active Effects on an actor and return a structured
+ * breakdown of every change that targets a specific data path (e.g.
+ * 'system.combat.attack.final.value').
+ *
+ * Used by the combat dialog and the chat-attack template to show which AE
+ * contributed how much to a given roll. Restores the traceability that was
+ * lost when AE started writing directly to *.final.value.
+ *
+ * @param {object} actor  Foundry actor. Reads `actor.effects.contents`,
+ *                        `actor` itself for the current value (post-AE) and
+ *                        `actor._source.system` for the pre-AE source value.
+ * @param {string} path   Dot-path to inspect, must start with 'system.'.
+ *                        E.g. 'system.combat.attack.final.value'.
+ * @returns {{
+ *   total: number,
+ *   linearTotal: number,
+ *   hasNonLinear: boolean,
+ *   items: Array<{
+ *     effectId: string,
+ *     effectName: string,
+ *     mode: 'add'|'multiply'|'override',
+ *     value: number|string,
+ *     isLinear: boolean
+ *   }>
+ * }}
+ */
+export function getActiveEffectsBreakdownForPath(actor, path) {
+  const items = [];
+  let linearTotal = 0;
+  let hasNonLinear = false;
+
+  const effects = actor?.effects?.contents ?? [];
+  for (const effect of effects) {
+    if (!effect.active) continue;
+
+    const changes = effect.changes;
+    if (!Array.isArray(changes) || changes.length === 0) continue;
+
+    for (const change of changes) {
+      if (change?.key !== path) continue;
+
+      const mode = normalizeChangeMode(change);
+      const numeric = Number(change.value);
+      const value = Number.isNaN(numeric) ? change.value : numeric;
+      const isLinear = mode === 'add' && typeof value === 'number';
+
+      items.push({
+        effectId: String(effect.id ?? ''),
+        effectName: String(effect.name ?? effect.label ?? '?'),
+        mode,
+        value,
+        isLinear
+      });
+
+      if (isLinear) {
+        linearTotal += value;
+      } else {
+        hasNonLinear = true;
+      }
+    }
+  }
+
+  // Authoritative total = current value (with AE applied) minus the source
+  // value (before AE). This is the diff the AE flow actually produced and is
+  // robust against any future code that also writes to the path.
+  const currentRaw = getProp(actor, path);
+  const sourcePath = path.startsWith('system.') ? path.slice('system.'.length) : path;
+  const sourceRaw = getProp(actor?._source?.system, sourcePath);
+
+  const current = Number(currentRaw) || 0;
+  const source = Number(sourceRaw) || 0;
+  const total = current - source;
+
+  return { total, linearTotal, hasNonLinear, items };
+}

--- a/src/module/actor/utils/activeEffectsBreakdown.js
+++ b/src/module/actor/utils/activeEffectsBreakdown.js
@@ -1,19 +1,18 @@
 // /module/actor/utils/activeEffectsBreakdown.js
+import { ATTRIBUTE_DERIVATION_MAP } from './attributeDerivationMap.js';
 
 /**
- * Normalize an Active Effect change to a logical mode string.
- * Kept in sync with the resolver in activeEffectApplicator.js — we cannot
- * import from inside the effectFow folder here because this helper is
- * consumed from UI/dialog code that should not depend on the full effect
- * flow machinery.
+ * Normalize an Active Effect change to a logical mode string. Kept in sync
+ * with the resolver in activeEffectApplicator.js so the trace and the actual
+ * applied effect always agree on what each change does.
  */
 function normalizeChangeMode(change) {
   if (typeof change?.type === 'string') return change.type;
   switch (change?.mode) {
     case 1: return 'multiply';
     case 2: return 'add';
-    case 3: return 'override'; // DOWNGRADE -> treated as override
-    case 4: return 'override'; // UPGRADE   -> treated as override
+    case 3: return 'override';
+    case 4: return 'override';
     case 5: return 'override';
     default: return 'add';
   }
@@ -31,36 +30,47 @@ function getProp(obj, path) {
 }
 
 /**
- * Inspect the active Active Effects on an actor and return a structured
- * breakdown of every change that targets a specific data path (e.g.
- * 'system.combat.attack.final.value').
- *
- * Used by the combat dialog and the chat-attack template to show which AE
- * contributed how much to a given roll. Restores the traceability that was
- * lost when AE started writing directly to *.final.value.
- *
- * @param {object} actor  Foundry actor. Reads `actor.effects.contents`,
- *                        `actor` itself for the current value (post-AE) and
- *                        `actor._source.system` for the pre-AE source value.
- * @param {string} path   Dot-path to inspect, must start with 'system.'.
- *                        E.g. 'system.combat.attack.final.value'.
- * @returns {{
- *   total: number,
- *   linearTotal: number,
- *   hasNonLinear: boolean,
- *   items: Array<{
- *     effectId: string,
- *     effectName: string,
- *     mode: 'add'|'multiply'|'override',
- *     value: number|string,
- *     isLinear: boolean
- *   }>
- * }}
+ * @typedef {Object} BreakdownItem
+ * @property {string} effectId
+ * @property {string} effectName
+ * @property {string} path          The change.key (which path the AE touches)
+ * @property {'add'|'multiply'|'override'} mode
+ * @property {number|string} value
+ * @property {boolean} isLinear     true when mode is 'add' and value is numeric
  */
-export function getActiveEffectsBreakdownForPath(actor, path) {
+
+/**
+ * @typedef {Object} Breakdown
+ * @property {number} total         Sum of linear contributions (for backward compat)
+ * @property {number} linearTotal   Same as total — kept for backward compat
+ * @property {boolean} hasNonLinear true if any contribution is multiply/override
+ * @property {BreakdownItem[]} items
+ */
+
+/**
+ * Iterate the active AE on an actor and collect every change whose key
+ * matches any of the `paths`. Each match becomes a BreakdownItem.
+ *
+ * The helper is path-set based on purpose: a single roll attribute (Ataque,
+ * Parada, Proyección mágica...) is derived from several paths in the system
+ * (the final value plus the modifiers that flow into it), and a relevant AE
+ * is one that touches ANY of them. By passing the full path set we surface
+ * indirect contributors (e.g. Ceguera parcial penalizing physicalActions
+ * shows up under Ataque too).
+ *
+ * @param {object} actor
+ * @param {string[]} paths
+ * @returns {Breakdown}
+ */
+export function getActiveEffectsBreakdownForPaths(actor, paths) {
   const items = [];
   let linearTotal = 0;
   let hasNonLinear = false;
+
+  const pathSet = new Set(paths ?? []);
+  if (pathSet.size === 0) {
+    return { total: 0, linearTotal: 0, hasNonLinear: false, items };
+  }
 
   const effects = actor?.effects?.contents ?? [];
   for (const effect of effects) {
@@ -70,7 +80,7 @@ export function getActiveEffectsBreakdownForPath(actor, path) {
     if (!Array.isArray(changes) || changes.length === 0) continue;
 
     for (const change of changes) {
-      if (change?.key !== path) continue;
+      if (!change?.key || !pathSet.has(change.key)) continue;
 
       const mode = normalizeChangeMode(change);
       const numeric = Number(change.value);
@@ -80,29 +90,57 @@ export function getActiveEffectsBreakdownForPath(actor, path) {
       items.push({
         effectId: String(effect.id ?? ''),
         effectName: String(effect.name ?? effect.label ?? '?'),
+        path: change.key,
         mode,
         value,
         isLinear
       });
 
-      if (isLinear) {
-        linearTotal += value;
-      } else {
-        hasNonLinear = true;
-      }
+      if (isLinear) linearTotal += value;
+      else hasNonLinear = true;
     }
   }
 
-  // Authoritative total = current value (with AE applied) minus the source
-  // value (before AE). This is the diff the AE flow actually produced and is
-  // robust against any future code that also writes to the path.
+  return { total: linearTotal, linearTotal, hasNonLinear, items };
+}
+
+/**
+ * Convenience wrapper: collect AE that affect a given roll attribute (one
+ * of the keys in ATTRIBUTE_DERIVATION_MAP). Resolves the contributing paths
+ * automatically.
+ *
+ * @param {object} actor
+ * @param {string} attributeName  e.g. 'attack', 'block', 'magicProjectionOffensive'
+ * @returns {Breakdown}
+ */
+export function getActiveEffectsBreakdownForAttribute(actor, attributeName) {
+  const paths = ATTRIBUTE_DERIVATION_MAP[attributeName];
+  if (!paths) {
+    return { total: 0, linearTotal: 0, hasNonLinear: false, items: [] };
+  }
+  return getActiveEffectsBreakdownForPaths(actor, paths);
+}
+
+/**
+ * Legacy API: collect AE that target exactly one path. Kept so existing
+ * callers (CombatAttackDialog, AttackConfigurationDialog) keep working
+ * during the migration to the attribute-based API. Internally delegates to
+ * the paths helper with a single-element list, and additionally computes a
+ * source-diff `total` so consumers can audit the AE flow result.
+ *
+ * @param {object} actor
+ * @param {string} path
+ * @returns {Breakdown}
+ */
+export function getActiveEffectsBreakdownForPath(actor, path) {
+  const result = getActiveEffectsBreakdownForPaths(actor, [path]);
+
+  // Maintain the previous semantics for `total` on single-path queries:
+  // actor diff (post-AE current value vs source value).
   const currentRaw = getProp(actor, path);
   const sourcePath = path.startsWith('system.') ? path.slice('system.'.length) : path;
   const sourceRaw = getProp(actor?._source?.system, sourcePath);
-
   const current = Number(currentRaw) || 0;
   const source = Number(sourceRaw) || 0;
-  const total = current - source;
-
-  return { total, linearTotal, hasNonLinear, items };
+  return { ...result, total: current - source };
 }

--- a/src/module/actor/utils/activeEffectsBreakdown.test.js
+++ b/src/module/actor/utils/activeEffectsBreakdown.test.js
@@ -87,7 +87,11 @@ describe('getActiveEffectsBreakdownForPaths (multi-path)', () => {
 });
 
 describe('getActiveEffectsBreakdownForAttribute (resolves derivation map)', () => {
-  it('attributes Ceguera (vía physicalActions) to the attack attribute', () => {
+  it('does NOT attribute physicalActions to the attack attribute (combat is primary)', () => {
+    // Per Anima Beyond Fantasy rules, physicalActions only modifies contested
+    // secondary skills. Combat skills (attack/block/dodge) are primary skills
+    // and are not derived from physicalActions, so an AE on physicalActions
+    // must not bubble up to the attack breakdown.
     const actor = makeActor({
       effects: [{
         id: 'ceguera', name: 'Ceguera parcial', active: true,
@@ -96,13 +100,12 @@ describe('getActiveEffectsBreakdownForAttribute (resolves derivation map)', () =
     });
 
     const res = getActiveEffectsBreakdownForAttribute(actor, 'attack');
-    expect(res.items).toHaveLength(1);
-    expect(res.items[0].effectName).toBe('Ceguera parcial');
-    expect(res.items[0].path).toBe(PHYSICAL_PATH);
-    expect(res.linearTotal).toBe(-30);
+    expect(res.items).toEqual([]);
+    expect(res.linearTotal).toBe(0);
   });
 
-  it('groups direct and indirect contributors under the same attribute', () => {
+  it('groups multiple direct contributors under the same attribute', () => {
+    const ATTACK_SPECIAL_PATH = 'system.combat.attack.special.value';
     const actor = makeActor({
       effects: [
         {
@@ -110,8 +113,8 @@ describe('getActiveEffectsBreakdownForAttribute (resolves derivation map)', () =
           changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
         },
         {
-          id: 'ceguera', name: 'Ceguera parcial', active: true,
-          changes: [{ key: PHYSICAL_PATH, value: '-30', type: 'add' }]
+          id: 'special', name: 'Buff especial', active: true,
+          changes: [{ key: ATTACK_SPECIAL_PATH, value: '-30', type: 'add' }]
         }
       ]
     });

--- a/src/module/actor/utils/activeEffectsBreakdown.test.js
+++ b/src/module/actor/utils/activeEffectsBreakdown.test.js
@@ -1,0 +1,204 @@
+import { getActiveEffectsBreakdownForPath } from './activeEffectsBreakdown.js';
+
+/**
+ * Build a minimal actor stub:
+ *  - `_source.system` holds the pre-AE value (what the GM has in the sheet).
+ *  - `system` holds the post-AE value (what would be read after the flow).
+ *  - `effects.contents` is an array of effect stubs with `active` and
+ *    `changes` exactly as a Foundry ActiveEffect would expose them.
+ */
+const makeActor = ({ sourceAttack, currentAttack, effects }) => ({
+  _source: {
+    system: {
+      combat: { attack: { final: { value: sourceAttack } } }
+    }
+  },
+  system: {
+    combat: { attack: { final: { value: currentAttack } } }
+  },
+  effects: { contents: effects }
+});
+
+const ATTACK_PATH = 'system.combat.attack.final.value';
+
+describe('getActiveEffectsBreakdownForPath', () => {
+  it('returns an empty breakdown when no effects target the path', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 100,
+      effects: []
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(0);
+    expect(res.linearTotal).toBe(0);
+    expect(res.hasNonLinear).toBe(false);
+    expect(res.items).toEqual([]);
+  });
+
+  it('lists a single add effect with its name and value', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 120,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Sangre de Orochi',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(20);
+    expect(res.linearTotal).toBe(20);
+    expect(res.hasNonLinear).toBe(false);
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0]).toMatchObject({
+      effectName: 'Sangre de Orochi',
+      mode: 'add',
+      value: 20,
+      isLinear: true
+    });
+  });
+
+  it('skips effects that are not active', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 100,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Sangre de Orochi',
+          active: false,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(0);
+    expect(res.items).toEqual([]);
+  });
+
+  it('skips changes that target a different path', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 100,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Some Block Buff',
+          active: true,
+          changes: [{ key: 'system.combat.block.final.value', value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(0);
+    expect(res.items).toEqual([]);
+  });
+
+  it('sums multiple linear adds and lists them individually', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 90, // +20 -30 = -10 net
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Sangre de Orochi',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        },
+        {
+          id: 'eff2',
+          name: 'Ceguera parcial',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '-30', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(-10);
+    expect(res.linearTotal).toBe(-10);
+    expect(res.hasNonLinear).toBe(false);
+    expect(res.items).toHaveLength(2);
+    expect(res.items.map(i => i.effectName)).toEqual(['Sangre de Orochi', 'Ceguera parcial']);
+  });
+
+  it('marks override effects as non-linear and does not include them in linearTotal', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 999,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Override Test',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '999', type: 'override' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(899); // current - source
+    expect(res.linearTotal).toBe(0);
+    expect(res.hasNonLinear).toBe(true);
+    expect(res.items[0].isLinear).toBe(false);
+    expect(res.items[0].mode).toBe('override');
+  });
+
+  it('handles Foundry-standard numeric mode (mode: 2 = ADD)', () => {
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 115,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Native AE',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '15', mode: 2 }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(15);
+    expect(res.items[0].isLinear).toBe(true);
+    expect(res.items[0].mode).toBe('add');
+  });
+
+  it('total reflects the actor diff even if items disagree (defensive)', () => {
+    // Edge case: items report +20 but the actor diff says -5. This can
+    // happen if some other code path also writes to the field, or if the
+    // AE flow has not run yet. We trust the actor diff as the authoritative
+    // total; items remain for nominal display.
+    const actor = makeActor({
+      sourceAttack: 100,
+      currentAttack: 95,
+      effects: [
+        {
+          id: 'eff1',
+          name: 'Listed',
+          active: true,
+          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        }
+      ]
+    });
+
+    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+
+    expect(res.total).toBe(-5);          // actor diff
+    expect(res.linearTotal).toBe(20);    // sum of listed items
+  });
+});

--- a/src/module/actor/utils/activeEffectsBreakdown.test.js
+++ b/src/module/actor/utils/activeEffectsBreakdown.test.js
@@ -1,13 +1,10 @@
-import { getActiveEffectsBreakdownForPath } from './activeEffectsBreakdown.js';
+import {
+  getActiveEffectsBreakdownForPath,
+  getActiveEffectsBreakdownForPaths,
+  getActiveEffectsBreakdownForAttribute
+} from './activeEffectsBreakdown.js';
 
-/**
- * Build a minimal actor stub:
- *  - `_source.system` holds the pre-AE value (what the GM has in the sheet).
- *  - `system` holds the post-AE value (what would be read after the flow).
- *  - `effects.contents` is an array of effect stubs with `active` and
- *    `changes` exactly as a Foundry ActiveEffect would expose them.
- */
-const makeActor = ({ sourceAttack, currentAttack, effects }) => ({
+const makeActor = ({ sourceAttack = 100, currentAttack = 100, effects = [] } = {}) => ({
   _source: {
     system: {
       combat: { attack: { final: { value: sourceAttack } } }
@@ -20,185 +17,113 @@ const makeActor = ({ sourceAttack, currentAttack, effects }) => ({
 });
 
 const ATTACK_PATH = 'system.combat.attack.final.value';
+const PHYSICAL_PATH = 'system.general.modifiers.physicalActions.final.value';
 
-describe('getActiveEffectsBreakdownForPath', () => {
-  it('returns an empty breakdown when no effects target the path', () => {
+describe('getActiveEffectsBreakdownForPath (single-path legacy API)', () => {
+  it('lists a single matching effect', () => {
     const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 100,
-      effects: []
+      sourceAttack: 100, currentAttack: 120,
+      effects: [{
+        id: 'eff1', name: 'Sangre de Orochi', active: true,
+        changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+      }]
     });
 
     const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
-
-    expect(res.total).toBe(0);
-    expect(res.linearTotal).toBe(0);
-    expect(res.hasNonLinear).toBe(false);
-    expect(res.items).toEqual([]);
-  });
-
-  it('lists a single add effect with its name and value', () => {
-    const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 120,
-      effects: [
-        {
-          id: 'eff1',
-          name: 'Sangre de Orochi',
-          active: true,
-          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
-        }
-      ]
-    });
-
-    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
-
-    expect(res.total).toBe(20);
-    expect(res.linearTotal).toBe(20);
-    expect(res.hasNonLinear).toBe(false);
     expect(res.items).toHaveLength(1);
-    expect(res.items[0]).toMatchObject({
-      effectName: 'Sangre de Orochi',
-      mode: 'add',
-      value: 20,
-      isLinear: true
-    });
+    expect(res.items[0].effectName).toBe('Sangre de Orochi');
+    expect(res.total).toBe(20);
   });
 
-  it('skips effects that are not active', () => {
+  it('returns total based on source-diff (defensive)', () => {
+    // current=95 source=100, but Orochi alone says +20. Diff = -5.
     const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 100,
-      effects: [
-        {
-          id: 'eff1',
-          name: 'Sangre de Orochi',
-          active: false,
-          changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
-        }
-      ]
+      sourceAttack: 100, currentAttack: 95,
+      effects: [{
+        id: 'eff1', name: 'X', active: true,
+        changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+      }]
     });
 
     const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
-
-    expect(res.total).toBe(0);
-    expect(res.items).toEqual([]);
+    expect(res.total).toBe(-5);          // source diff
+    expect(res.linearTotal).toBe(20);    // items sum
   });
+});
 
-  it('skips changes that target a different path', () => {
+describe('getActiveEffectsBreakdownForPaths (multi-path)', () => {
+  it('collects effects targeting any of the provided paths', () => {
     const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 100,
       effects: [
         {
-          id: 'eff1',
-          name: 'Some Block Buff',
-          active: true,
-          changes: [{ key: 'system.combat.block.final.value', value: '20', type: 'add' }]
-        }
-      ]
-    });
-
-    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
-
-    expect(res.total).toBe(0);
-    expect(res.items).toEqual([]);
-  });
-
-  it('sums multiple linear adds and lists them individually', () => {
-    const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 90, // +20 -30 = -10 net
-      effects: [
-        {
-          id: 'eff1',
-          name: 'Sangre de Orochi',
-          active: true,
+          id: 'orochi', name: 'Sangre de Orochi', active: true,
           changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
         },
         {
-          id: 'eff2',
-          name: 'Ceguera parcial',
-          active: true,
-          changes: [{ key: ATTACK_PATH, value: '-30', type: 'add' }]
+          id: 'ceguera', name: 'Ceguera parcial', active: true,
+          changes: [{ key: PHYSICAL_PATH, value: '-30', type: 'add' }]
         }
       ]
     });
 
-    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+    const res = getActiveEffectsBreakdownForPaths(actor, [ATTACK_PATH, PHYSICAL_PATH]);
 
-    expect(res.total).toBe(-10);
-    expect(res.linearTotal).toBe(-10);
-    expect(res.hasNonLinear).toBe(false);
     expect(res.items).toHaveLength(2);
     expect(res.items.map(i => i.effectName)).toEqual(['Sangre de Orochi', 'Ceguera parcial']);
+    expect(res.linearTotal).toBe(-10);
   });
 
-  it('marks override effects as non-linear and does not include them in linearTotal', () => {
+  it('ignores effects that target unrelated paths', () => {
     const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 999,
-      effects: [
-        {
-          id: 'eff1',
-          name: 'Override Test',
-          active: true,
-          changes: [{ key: ATTACK_PATH, value: '999', type: 'override' }]
-        }
-      ]
+      effects: [{
+        id: 'dodge', name: 'Some Dodge Buff', active: true,
+        changes: [{ key: 'system.combat.dodge.final.value', value: '15', type: 'add' }]
+      }]
     });
 
-    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
-
-    expect(res.total).toBe(899); // current - source
-    expect(res.linearTotal).toBe(0);
-    expect(res.hasNonLinear).toBe(true);
-    expect(res.items[0].isLinear).toBe(false);
-    expect(res.items[0].mode).toBe('override');
+    const res = getActiveEffectsBreakdownForPaths(actor, [ATTACK_PATH, PHYSICAL_PATH]);
+    expect(res.items).toEqual([]);
   });
+});
 
-  it('handles Foundry-standard numeric mode (mode: 2 = ADD)', () => {
+describe('getActiveEffectsBreakdownForAttribute (resolves derivation map)', () => {
+  it('attributes Ceguera (vía physicalActions) to the attack attribute', () => {
     const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 115,
-      effects: [
-        {
-          id: 'eff1',
-          name: 'Native AE',
-          active: true,
-          changes: [{ key: ATTACK_PATH, value: '15', mode: 2 }]
-        }
-      ]
+      effects: [{
+        id: 'ceguera', name: 'Ceguera parcial', active: true,
+        changes: [{ key: PHYSICAL_PATH, value: '-30', type: 'add' }]
+      }]
     });
 
-    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
-
-    expect(res.total).toBe(15);
-    expect(res.items[0].isLinear).toBe(true);
-    expect(res.items[0].mode).toBe('add');
+    const res = getActiveEffectsBreakdownForAttribute(actor, 'attack');
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0].effectName).toBe('Ceguera parcial');
+    expect(res.items[0].path).toBe(PHYSICAL_PATH);
+    expect(res.linearTotal).toBe(-30);
   });
 
-  it('total reflects the actor diff even if items disagree (defensive)', () => {
-    // Edge case: items report +20 but the actor diff says -5. This can
-    // happen if some other code path also writes to the field, or if the
-    // AE flow has not run yet. We trust the actor diff as the authoritative
-    // total; items remain for nominal display.
+  it('groups direct and indirect contributors under the same attribute', () => {
     const actor = makeActor({
-      sourceAttack: 100,
-      currentAttack: 95,
       effects: [
         {
-          id: 'eff1',
-          name: 'Listed',
-          active: true,
+          id: 'orochi', name: 'Sangre de Orochi', active: true,
           changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }]
+        },
+        {
+          id: 'ceguera', name: 'Ceguera parcial', active: true,
+          changes: [{ key: PHYSICAL_PATH, value: '-30', type: 'add' }]
         }
       ]
     });
 
-    const res = getActiveEffectsBreakdownForPath(actor, ATTACK_PATH);
+    const res = getActiveEffectsBreakdownForAttribute(actor, 'attack');
+    expect(res.items).toHaveLength(2);
+    expect(res.linearTotal).toBe(-10);
+  });
 
-    expect(res.total).toBe(-5);          // actor diff
-    expect(res.linearTotal).toBe(20);    // sum of listed items
+  it('returns empty for unknown attribute', () => {
+    const actor = makeActor();
+    const res = getActiveEffectsBreakdownForAttribute(actor, 'nopeNope');
+    expect(res.items).toEqual([]);
   });
 });

--- a/src/module/actor/utils/aeBreakdownFormat.js
+++ b/src/module/actor/utils/aeBreakdownFormat.js
@@ -7,6 +7,11 @@
  * are labelled so the GM knows the formula could not split them out
  * cleanly.
  *
+ * One entry per change. If a single AE writes to several paths that all
+ * feed into the same roll, each change is listed on its own — that visible
+ * separation is what surfaces routing bugs (e.g. a path leaking into the
+ * wrong attribute), so we deliberately do NOT group by effect name here.
+ *
  * Shared between CombatAttackDialog and AttackConfigurationDialog (and any
  * future dialog that wants to expose the same nominal trace in chat).
  *
@@ -21,7 +26,6 @@ export function formatAeBreakdownForFlavor(breakdown) {
       const sign = it.value >= 0 ? '+' : '';
       return `${it.effectName} (${sign}${it.value})`;
     }
-    // Non-linear: don't claim a delta we cannot honestly show.
     const tag = it.mode === 'override' ? 'override' : it.mode;
     return `${it.effectName} (${tag})`;
   });

--- a/src/module/actor/utils/aeBreakdownFormat.js
+++ b/src/module/actor/utils/aeBreakdownFormat.js
@@ -1,0 +1,31 @@
+// /module/actor/utils/aeBreakdownFormat.js
+
+/**
+ * Build the HTML snippet appended to a roll's flavor that lists the Active
+ * Effects contributing to an attribute used in the roll. Linear (add)
+ * effects show their signed delta; non-linear effects (multiply/override)
+ * are labelled so the GM knows the formula could not split them out
+ * cleanly.
+ *
+ * Shared between CombatAttackDialog and AttackConfigurationDialog (and any
+ * future dialog that wants to expose the same nominal trace in chat).
+ *
+ * @param {{items: Array, hasNonLinear: boolean}} breakdown
+ * @returns {string} HTML to append to a roll flavor, empty if no items.
+ */
+export function formatAeBreakdownForFlavor(breakdown) {
+  if (!breakdown?.items?.length) return '';
+
+  const parts = breakdown.items.map(it => {
+    if (it.isLinear) {
+      const sign = it.value >= 0 ? '+' : '';
+      return `${it.effectName} (${sign}${it.value})`;
+    }
+    // Non-linear: don't claim a delta we cannot honestly show.
+    const tag = it.mode === 'override' ? 'override' : it.mode;
+    return `${it.effectName} (${tag})`;
+  });
+
+  const label = breakdown.hasNonLinear ? 'Mod (no descompuesto)' : 'Mod';
+  return `<br><small><em>${label}: ${parts.join(', ')}</em></small>`;
+}

--- a/src/module/actor/utils/attributeDerivationMap.js
+++ b/src/module/actor/utils/attributeDerivationMap.js
@@ -1,0 +1,112 @@
+// /module/actor/utils/attributeDerivationMap.js
+
+/**
+ * Mapping of every rollable attribute in the system to the list of data
+ * paths that contribute to its final value. Used by the trace pipeline so
+ * an AE that modifies any contributing path is attributed to the right
+ * roll in the chat (e.g. Ceguera parcial penalizing physicalActions shows
+ * up under Ataque, Parada, Esquiva and Acciones Físicas).
+ *
+ * Every entry lists the FINAL path first (the one the roll reads) and then
+ * any upstream paths that flow into it through mutateCombatData or related
+ * derived calculations.
+ *
+ * Keys here are stable identifiers used by inferAttributeFromFlavor and
+ * by direct callers; they don't need to match Foundry's data paths.
+ */
+export const ATTRIBUTE_DERIVATION_MAP = {
+  attack: [
+    'system.combat.attack.final.value',
+    'system.combat.attack.base.value',
+    'system.combat.attack.special.value',
+    'system.general.modifiers.allActions.final.value',
+    'system.general.modifiers.physicalActions.final.value'
+  ],
+  block: [
+    'system.combat.block.final.value',
+    'system.combat.block.base.value',
+    'system.combat.block.special.value',
+    'system.general.modifiers.allActions.final.value',
+    'system.general.modifiers.physicalActions.final.value'
+  ],
+  dodge: [
+    'system.combat.dodge.final.value',
+    'system.combat.dodge.base.value',
+    'system.combat.dodge.special.value',
+    'system.general.modifiers.allActions.final.value',
+    'system.general.modifiers.physicalActions.final.value'
+  ],
+  initiative: [
+    'system.characteristics.secondaries.initiative.final.value',
+    'system.characteristics.secondaries.initiative.base.value',
+    'system.general.modifiers.allActions.final.value'
+  ],
+  magicProjectionOffensive: [
+    'system.mystic.magicProjection.imbalance.offensive.final.value',
+    'system.mystic.magicProjection.imbalance.offensive.base.value',
+    'system.mystic.magicProjection.final.value',
+    'system.mystic.magicProjection.base.value',
+    'system.general.modifiers.allActions.final.value'
+  ],
+  magicProjectionDefensive: [
+    'system.mystic.magicProjection.imbalance.defensive.final.value',
+    'system.mystic.magicProjection.imbalance.defensive.base.value',
+    'system.mystic.magicProjection.final.value',
+    'system.mystic.magicProjection.base.value',
+    'system.general.modifiers.allActions.final.value'
+  ],
+  psychicProjectionOffensive: [
+    'system.psychic.psychicProjection.imbalance.offensive.final.value',
+    'system.psychic.psychicProjection.imbalance.offensive.base.value',
+    'system.psychic.psychicProjection.final.value',
+    'system.psychic.psychicProjection.base.value',
+    'system.general.modifiers.allActions.final.value'
+  ],
+  psychicProjectionDefensive: [
+    'system.psychic.psychicProjection.imbalance.defensive.final.value',
+    'system.psychic.psychicProjection.imbalance.defensive.base.value',
+    'system.psychic.psychicProjection.final.value',
+    'system.psychic.psychicProjection.base.value',
+    'system.general.modifiers.allActions.final.value'
+  ],
+  physicalAction: [
+    'system.general.modifiers.physicalActions.final.value',
+    'system.general.modifiers.physicalActions.base.value',
+    'system.general.modifiers.allActions.final.value'
+  ]
+};
+
+/**
+ * Infer the attribute key (one of ATTRIBUTE_DERIVATION_MAP) from a roll
+ * flavor string. Robust to the system's mix of Spanish and English flavor
+ * texts; returns null if no confident match.
+ *
+ * Order matters: more specific patterns first, then generic ones.
+ *
+ * @param {string} flavor
+ * @returns {string|null}
+ */
+export function inferAttributeFromFlavor(flavor) {
+  if (typeof flavor !== 'string' || !flavor) return null;
+  const f = flavor.toLowerCase();
+
+  // Magic projection — offensive vs defensive
+  if (f.includes('proyección mágica') || f.includes('proyeccion magica') || f.includes('magic projection')) {
+    if (f.includes('defensiv')) return 'magicProjectionDefensive';
+    return 'magicProjectionOffensive';
+  }
+  // Psychic projection — offensive vs defensive
+  if (f.includes('proyección psíquica') || f.includes('proyeccion psiquica') || f.includes('psychic projection')) {
+    if (f.includes('defensiv')) return 'psychicProjectionDefensive';
+    return 'psychicProjectionOffensive';
+  }
+
+  if (/\bparada\b/.test(f) || /\bblock\b/.test(f)) return 'block';
+  if (/\besquiva\b/.test(f) || /\bdodge\b/.test(f)) return 'dodge';
+  if (/\biniciativa\b/.test(f) || /\binitiative\b/.test(f)) return 'initiative';
+
+  // Attack catches "rolling attack" and "physicalAttack" etc.
+  if (/\battack\b/.test(f) || /\bataque\b/.test(f)) return 'attack';
+
+  return null;
+}

--- a/src/module/actor/utils/attributeDerivationMap.js
+++ b/src/module/actor/utils/attributeDerivationMap.js
@@ -15,26 +15,24 @@
  * by direct callers; they don't need to match Foundry's data paths.
  */
 export const ATTRIBUTE_DERIVATION_MAP = {
+  // Attack, block and dodge are primary combat skills. They do NOT receive
+  // the physicalActions modifier (which only applies to contested secondary
+  // skills per the Anima rules). Only AE that touch the attribute paths
+  // directly contribute to the flavor.
   attack: [
     'system.combat.attack.final.value',
     'system.combat.attack.base.value',
-    'system.combat.attack.special.value',
-    'system.general.modifiers.allActions.final.value',
-    'system.general.modifiers.physicalActions.final.value'
+    'system.combat.attack.special.value'
   ],
   block: [
     'system.combat.block.final.value',
     'system.combat.block.base.value',
-    'system.combat.block.special.value',
-    'system.general.modifiers.allActions.final.value',
-    'system.general.modifiers.physicalActions.final.value'
+    'system.combat.block.special.value'
   ],
   dodge: [
     'system.combat.dodge.final.value',
     'system.combat.dodge.base.value',
-    'system.combat.dodge.special.value',
-    'system.general.modifiers.allActions.final.value',
-    'system.general.modifiers.physicalActions.final.value'
+    'system.combat.dodge.special.value'
   ],
   initiative: [
     'system.characteristics.secondaries.initiative.final.value',

--- a/src/module/actor/utils/attributeDerivationMap.test.js
+++ b/src/module/actor/utils/attributeDerivationMap.test.js
@@ -1,0 +1,73 @@
+import {
+  ATTRIBUTE_DERIVATION_MAP,
+  inferAttributeFromFlavor
+} from './attributeDerivationMap.js';
+
+describe('ATTRIBUTE_DERIVATION_MAP', () => {
+  it('lists multiple contributing paths for combat attributes', () => {
+    expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.combat.attack.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.general.modifiers.physicalActions.final.value');
+  });
+
+  it('block and dodge follow the same shape as attack', () => {
+    expect(ATTRIBUTE_DERIVATION_MAP.block).toContain('system.combat.block.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.dodge).toContain('system.combat.dodge.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.block).toContain('system.general.modifiers.physicalActions.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.dodge).toContain('system.general.modifiers.physicalActions.final.value');
+  });
+
+  it('magic and psychic projection have offensive/defensive variants', () => {
+    expect(ATTRIBUTE_DERIVATION_MAP.magicProjectionOffensive).toContain('system.mystic.magicProjection.imbalance.offensive.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.magicProjectionDefensive).toContain('system.mystic.magicProjection.imbalance.defensive.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.psychicProjectionOffensive).toContain('system.psychic.psychicProjection.imbalance.offensive.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.psychicProjectionDefensive).toContain('system.psychic.psychicProjection.imbalance.defensive.final.value');
+  });
+});
+
+describe('inferAttributeFromFlavor', () => {
+  it('returns null on empty or unrecognized flavor', () => {
+    expect(inferAttributeFromFlavor('')).toBeNull();
+    expect(inferAttributeFromFlavor('Some random text')).toBeNull();
+    expect(inferAttributeFromFlavor(null)).toBeNull();
+    expect(inferAttributeFromFlavor(undefined)).toBeNull();
+  });
+
+  it('detects attack from Spanish and English flavors', () => {
+    expect(inferAttributeFromFlavor('Rolling attack')).toBe('attack');
+    expect(inferAttributeFromFlavor('Ataque físico con Hacha de guerra')).toBe('attack');
+    expect(inferAttributeFromFlavor('PhysicalAttack: ataque')).toBe('attack');
+  });
+
+  it('detects block (parada)', () => {
+    expect(inferAttributeFromFlavor('Rolling parada')).toBe('block');
+    expect(inferAttributeFromFlavor('Block roll')).toBe('block');
+  });
+
+  it('detects dodge (esquiva)', () => {
+    expect(inferAttributeFromFlavor('Rolling esquiva')).toBe('dodge');
+    expect(inferAttributeFromFlavor('Dodge')).toBe('dodge');
+  });
+
+  it('detects initiative', () => {
+    expect(inferAttributeFromFlavor('Iniciativa')).toBe('initiative');
+    expect(inferAttributeFromFlavor('Rolling initiative')).toBe('initiative');
+  });
+
+  it('detects magic projection — offensive when no defensive keyword', () => {
+    expect(inferAttributeFromFlavor('Rolling proyección mágica ofensiva')).toBe('magicProjectionOffensive');
+    expect(inferAttributeFromFlavor('Magic projection roll')).toBe('magicProjectionOffensive');
+  });
+
+  it('detects magic projection defensive', () => {
+    expect(inferAttributeFromFlavor('Rolling proyección mágica defensiva')).toBe('magicProjectionDefensive');
+  });
+
+  it('detects psychic projection variants', () => {
+    expect(inferAttributeFromFlavor('Proyección psíquica ofensiva')).toBe('psychicProjectionOffensive');
+    expect(inferAttributeFromFlavor('Proyección psíquica defensiva')).toBe('psychicProjectionDefensive');
+  });
+
+  it('handles missing accents (proyeccion magica)', () => {
+    expect(inferAttributeFromFlavor('proyeccion magica')).toBe('magicProjectionOffensive');
+  });
+});

--- a/src/module/actor/utils/attributeDerivationMap.test.js
+++ b/src/module/actor/utils/attributeDerivationMap.test.js
@@ -6,11 +6,21 @@ import {
 describe('ATTRIBUTE_DERIVATION_MAP', () => {
   it('includes the expected paths per attribute', () => {
     expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.combat.attack.final.value');
-    expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.general.modifiers.physicalActions.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.combat.attack.base.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.combat.attack.special.value');
     expect(ATTRIBUTE_DERIVATION_MAP.block).toContain('system.combat.block.final.value');
     expect(ATTRIBUTE_DERIVATION_MAP.dodge).toContain('system.combat.dodge.final.value');
     expect(ATTRIBUTE_DERIVATION_MAP.magicProjectionOffensive).toContain('system.mystic.magicProjection.imbalance.offensive.final.value');
     expect(ATTRIBUTE_DERIVATION_MAP.psychicProjectionDefensive).toContain('system.psychic.psychicProjection.imbalance.defensive.final.value');
+  });
+
+  it('does NOT include physicalActions in attack/block/dodge (combat skills are primary, not secondary)', () => {
+    // Per Anima Beyond Fantasy rules, the physicalActions modifier applies only
+    // to contested secondary skills. Combat skills (attack, block, dodge) are
+    // primary skills and must not pull from this modifier.
+    expect(ATTRIBUTE_DERIVATION_MAP.attack).not.toContain('system.general.modifiers.physicalActions.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.block).not.toContain('system.general.modifiers.physicalActions.final.value');
+    expect(ATTRIBUTE_DERIVATION_MAP.dodge).not.toContain('system.general.modifiers.physicalActions.final.value');
   });
 });
 
@@ -46,5 +56,4 @@ describe('inferAttributeFromFlavor', () => {
     expect(inferAttributeFromFlavor('Proyección psíquica ofensiva')).toBe('psychicProjectionOffensive');
     expect(inferAttributeFromFlavor('Proyección psíquica defensiva')).toBe('psychicProjectionDefensive');
   });
-
 });

--- a/src/module/actor/utils/attributeDerivationMap.test.js
+++ b/src/module/actor/utils/attributeDerivationMap.test.js
@@ -4,22 +4,12 @@ import {
 } from './attributeDerivationMap.js';
 
 describe('ATTRIBUTE_DERIVATION_MAP', () => {
-  it('lists multiple contributing paths for combat attributes', () => {
+  it('includes the expected paths per attribute', () => {
     expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.combat.attack.final.value');
     expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain('system.general.modifiers.physicalActions.final.value');
-  });
-
-  it('block and dodge follow the same shape as attack', () => {
     expect(ATTRIBUTE_DERIVATION_MAP.block).toContain('system.combat.block.final.value');
     expect(ATTRIBUTE_DERIVATION_MAP.dodge).toContain('system.combat.dodge.final.value');
-    expect(ATTRIBUTE_DERIVATION_MAP.block).toContain('system.general.modifiers.physicalActions.final.value');
-    expect(ATTRIBUTE_DERIVATION_MAP.dodge).toContain('system.general.modifiers.physicalActions.final.value');
-  });
-
-  it('magic and psychic projection have offensive/defensive variants', () => {
     expect(ATTRIBUTE_DERIVATION_MAP.magicProjectionOffensive).toContain('system.mystic.magicProjection.imbalance.offensive.final.value');
-    expect(ATTRIBUTE_DERIVATION_MAP.magicProjectionDefensive).toContain('system.mystic.magicProjection.imbalance.defensive.final.value');
-    expect(ATTRIBUTE_DERIVATION_MAP.psychicProjectionOffensive).toContain('system.psychic.psychicProjection.imbalance.offensive.final.value');
     expect(ATTRIBUTE_DERIVATION_MAP.psychicProjectionDefensive).toContain('system.psychic.psychicProjection.imbalance.defensive.final.value');
   });
 });
@@ -36,16 +26,6 @@ describe('inferAttributeFromFlavor', () => {
     expect(inferAttributeFromFlavor('Rolling attack')).toBe('attack');
     expect(inferAttributeFromFlavor('Ataque físico con Hacha de guerra')).toBe('attack');
     expect(inferAttributeFromFlavor('PhysicalAttack: ataque')).toBe('attack');
-  });
-
-  it('detects block (parada)', () => {
-    expect(inferAttributeFromFlavor('Rolling parada')).toBe('block');
-    expect(inferAttributeFromFlavor('Block roll')).toBe('block');
-  });
-
-  it('detects dodge (esquiva)', () => {
-    expect(inferAttributeFromFlavor('Rolling esquiva')).toBe('dodge');
-    expect(inferAttributeFromFlavor('Dodge')).toBe('dodge');
   });
 
   it('detects initiative', () => {
@@ -67,7 +47,4 @@ describe('inferAttributeFromFlavor', () => {
     expect(inferAttributeFromFlavor('Proyección psíquica defensiva')).toBe('psychicProjectionDefensive');
   });
 
-  it('handles missing accents (proyeccion magica)', () => {
-    expect(inferAttributeFromFlavor('proyeccion magica')).toBe('magicProjectionOffensive');
-  });
 });

--- a/src/module/actor/utils/buttonCallbacks/createWeaponAttack.js
+++ b/src/module/actor/utils/buttonCallbacks/createWeaponAttack.js
@@ -11,7 +11,14 @@ export function createWeaponAttack(sheet, e) {
   const weapon = sheet.actor?.items?.get(weaponId);
   if (!weapon) return ui.notifications.warn('Arma no encontrada.');
 
-  const attackerToken = sheet.token ?? sheet.actor?.getActiveTokens?.()[0];
+  // Prefer the sheet's token (when the sheet was opened from a token on the
+  // canvas) over a generic getActiveTokens lookup. On unlinked tokens the
+  // sheet.token already carries the ActorDelta we need to read AE from;
+  // grabbing a random active token via the world actor can produce a
+  // different one. If neither is available we fall back to the first active
+  // token only as a last resort.
+  const sheetToken = sheet.token ?? sheet.object?.document ?? null;
+  const attackerToken = sheetToken ?? sheet.actor?.getActiveTokens?.()[0] ?? null;
   if (!attackerToken) return ui.notifications.warn('No attacker token found.');
 
   const snapshotTargets = getSnapshotTargets();

--- a/src/module/actor/utils/chatFlavorTrace.integration.test.js
+++ b/src/module/actor/utils/chatFlavorTrace.integration.test.js
@@ -10,16 +10,17 @@ import { formatAeBreakdownForFlavor } from './aeBreakdownFormat.js';
  *   actor + attribute -> getActiveEffectsBreakdownForAttribute -> breakdown
  *   breakdown -> formatAeBreakdownForFlavor -> HTML suffix
  *
- * If this suite passes the hook is guaranteed correct for the cases covered;
- * the only remaining unknown is the Foundry-side wiring (speaker -> actor
- * resolution), which is validated manually.
+ * IMPORTANT: per the Anima Beyond Fantasy rules, the physicalActions
+ * modifier is NOT applied to attack/block/dodge (those are primary combat
+ * skills). physicalActions only affects contested secondary skills. The
+ * derivation map and these tests reflect that: only AE that touch the
+ * attribute's own paths contribute to its flavor.
  */
 
 const ATTACK_PATH = 'system.combat.attack.final.value';
-const PHYSICAL_PATH = 'system.general.modifiers.physicalActions.final.value';
-const ALL_ACTIONS_PATH = 'system.general.modifiers.allActions.final.value';
 const BLOCK_PATH = 'system.combat.block.final.value';
 const DODGE_PATH = 'system.combat.dodge.final.value';
+const PHYSICAL_PATH = 'system.general.modifiers.physicalActions.final.value';
 const INITIATIVE_PATH = 'system.characteristics.secondaries.initiative.final.value';
 const MAGIC_OFFENSIVE_PATH = 'system.mystic.magicProjection.imbalance.offensive.final.value';
 const PSYCHIC_OFFENSIVE_PATH = 'system.psychic.psychicProjection.imbalance.offensive.final.value';
@@ -38,7 +39,6 @@ const mkEffect = (id, name, changes, opts = {}) => ({
   system: {}
 });
 
-/** End-to-end pipeline: same logic the hook runs. */
 function runFlavorPipeline(actor, flavor) {
   const attribute = inferAttributeFromFlavor(flavor);
   if (!attribute) return { attribute: null, breakdown: null, suffix: '' };
@@ -49,7 +49,7 @@ function runFlavorPipeline(actor, flavor) {
 
 describe('end-to-end flavor trace pipeline', () => {
   describe('Ataque', () => {
-    it('attributes Sangre de Orochi (direct on attack.final) to ataque', () => {
+    it('lists an AE that targets attack.final directly (Sangre de Orochi)', () => {
       const actor = mkActor([
         mkEffect('orochi', 'Sangre de Orochi', [
           { key: ATTACK_PATH, value: '20', type: 'add' }
@@ -61,7 +61,7 @@ describe('end-to-end flavor trace pipeline', () => {
       expect(suffix).toContain('Sangre de Orochi (+20)');
     });
 
-    it('attributes Ceguera parcial (indirect via physicalActions) to ataque', () => {
+    it('does NOT list AE that only touch physicalActions (Ceguera parcial via physical)', () => {
       const actor = mkActor([
         mkEffect('ceguera', 'Ceguera parcial', [
           { key: PHYSICAL_PATH, value: '-30', type: 'add' }
@@ -70,29 +70,26 @@ describe('end-to-end flavor trace pipeline', () => {
 
       const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling attack');
       expect(attribute).toBe('attack');
-      expect(suffix).toContain('Ceguera parcial (-30)');
+      // physicalActions does not affect attack rolls.
+      expect(suffix).toBe('');
     });
 
-    it('combines direct and indirect contributors under the same flavor', () => {
+    it('combines multiple direct contributors', () => {
       const actor = mkActor([
         mkEffect('orochi', 'Sangre de Orochi', [
           { key: ATTACK_PATH, value: '20', type: 'add' }
         ]),
         mkEffect('berserker', 'Berserker', [
           { key: ATTACK_PATH, value: '10', type: 'add' }
-        ]),
-        mkEffect('ceguera', 'Ceguera parcial', [
-          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
         ])
       ]);
 
       const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
       expect(suffix).toContain('Sangre de Orochi (+20)');
       expect(suffix).toContain('Berserker (+10)');
-      expect(suffix).toContain('Ceguera parcial (-30)');
     });
 
-    it('ignores effects on unrelated attributes (dodge buff doesn’t pollute ataque)', () => {
+    it('ignores effects that target other attributes', () => {
       const actor = mkActor([
         mkEffect('dodgeBuff', 'Aquarius', [
           { key: DODGE_PATH, value: '15', type: 'add' }
@@ -102,36 +99,40 @@ describe('end-to-end flavor trace pipeline', () => {
       const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
       expect(suffix).toBe('');
     });
-
   });
 
   describe('Parada y esquiva', () => {
-    it('attributes Ceguera parcial to parada via the shared physicalActions modifier', () => {
-      const actor = mkActor([
-        mkEffect('ceguera', 'Ceguera parcial', [
-          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
-        ])
-      ]);
-
-      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling parada');
-      expect(attribute).toBe('block');
-      expect(suffix).toContain('Ceguera parcial (-30)');
-    });
-
-    it('a dodge-only buff appears under esquiva but not parada', () => {
+    it('attributes a direct dodge buff under esquiva but not under parada', () => {
       const actor = mkActor([
         mkEffect('aquarius', 'Aquarius', [
           { key: DODGE_PATH, value: '15', type: 'add' }
         ])
       ]);
-
       expect(runFlavorPipeline(actor, 'Rolling esquiva').suffix).toContain('Aquarius (+15)');
       expect(runFlavorPipeline(actor, 'Rolling parada').suffix).toBe('');
+    });
+
+    it('does NOT list physicalActions-only AE under parada either', () => {
+      const actor = mkActor([
+        mkEffect('ceguera', 'Ceguera parcial', [
+          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
+        ])
+      ]);
+      expect(runFlavorPipeline(actor, 'Rolling parada').suffix).toBe('');
+    });
+
+    it('lists a direct block AE under parada', () => {
+      const actor = mkActor([
+        mkEffect('orochi', 'Sangre de Orochi', [
+          { key: BLOCK_PATH, value: '20', type: 'add' }
+        ])
+      ]);
+      expect(runFlavorPipeline(actor, 'Rolling parada').suffix).toContain('Sangre de Orochi (+20)');
     });
   });
 
   describe('Iniciativa', () => {
-    it('attributes Derribado (indirect — initiative penalty)', () => {
+    it('lists AE that touches initiative.final', () => {
       const actor = mkActor([
         mkEffect('derribado', 'Derribado', [
           { key: INITIATIVE_PATH, value: '-10', type: 'add' }
@@ -145,7 +146,7 @@ describe('end-to-end flavor trace pipeline', () => {
   });
 
   describe('Proyección mágica y psíquica', () => {
-    it('catches the offensive magic projection flavor', () => {
+    it('catches an AE that buffs offensive magic projection', () => {
       const actor = mkActor([
         mkEffect('seraphite', 'Seraphite', [
           { key: MAGIC_OFFENSIVE_PATH, value: '30', type: 'add' }
@@ -157,15 +158,16 @@ describe('end-to-end flavor trace pipeline', () => {
       expect(suffix).toContain('Seraphite (+30)');
     });
 
-    it('does not cross-pollinate offensive and defensive projections', () => {
+    it('catches an AE that buffs offensive psychic projection', () => {
       const actor = mkActor([
-        mkEffect('something', 'Defensive Buff', [
-          { key: 'system.mystic.magicProjection.imbalance.defensive.final.value', value: '30', type: 'add' }
+        mkEffect('shephon', 'Shephon', [
+          { key: PSYCHIC_OFFENSIVE_PATH, value: '20', type: 'add' }
         ])
       ]);
 
-      expect(runFlavorPipeline(actor, 'Rolling proyección mágica ofensiva').suffix).toBe('');
-      expect(runFlavorPipeline(actor, 'Rolling proyección mágica defensiva').suffix).toContain('Defensive Buff (+30)');
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling proyección psíquica ofensiva');
+      expect(attribute).toBe('psychicProjectionOffensive');
+      expect(suffix).toContain('Shephon (+20)');
     });
   });
 
@@ -188,11 +190,6 @@ describe('end-to-end flavor trace pipeline', () => {
       expect(runFlavorPipeline(actor, 'Rolling attack').suffix).toBe('');
     });
 
-    it('actor with no AE produces no suffix', () => {
-      const actor = mkActor([]);
-      expect(runFlavorPipeline(actor, 'Rolling attack').suffix).toBe('');
-    });
-
     it('override mode is rendered as non-linear (no signed delta)', () => {
       const actor = mkActor([
         mkEffect('shinkyou', 'Shinkyou (Posición Espejo)', [
@@ -203,27 +200,43 @@ describe('end-to-end flavor trace pipeline', () => {
       expect(suffix).toContain('Shinkyou (Posición Espejo) (override)');
       expect(suffix).toContain('Mod (no descompuesto)');
     });
+  });
 
-    it('Sigrid scenario: Orochi + Berserker + Ceguera parcial all listed under attack', () => {
+  describe('Una entrada por change (mismo AE, varios paths)', () => {
+    it('lista por separado cada change de un mismo effect (sin agrupar)', () => {
+      // Hypothetical AE that buffs attack from two direct paths simultaneously
+      // (base + special). Each change is listed on its own — la separación es
+      // intencional: gracias a esto detectamos rutas mal cableadas (p.ej. el
+      // bug de physicalActions filtrándose a attack).
       const actor = mkActor([
-        mkEffect('orochi', 'Sangre de Orochi - Sangre de la Violencia', [
-          { key: ATTACK_PATH, value: '20', type: 'add' }
-        ]),
-        mkEffect('berserker', 'Berserker', [
-          { key: ATTACK_PATH, value: '10', type: 'add' }
-        ]),
-        mkEffect('ceguera', 'Ceguera parcial', [
-          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
+        mkEffect('combo', 'Combo Buff', [
+          { key: ATTACK_PATH, value: '20', type: 'add' },
+          { key: 'system.combat.attack.special.value', value: '10', type: 'add' }
         ])
       ]);
 
-      const { suffix, breakdown } = runFlavorPipeline(actor, 'Rolling attack');
-      expect(breakdown.items).toHaveLength(3);
-      expect(breakdown.linearTotal).toBe(0); // 20 + 10 - 30 = 0
-      expect(suffix).toContain('Sangre de Orochi');
-      expect(suffix).toContain('Berserker');
-      expect(suffix).toContain('Ceguera parcial');
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toContain('Combo Buff (+20)');
+      expect(suffix).toContain('Combo Buff (+10)');
+      const occurrences = (suffix.match(/Combo Buff/g) ?? []).length;
+      expect(occurrences).toBe(2);
+    });
+
+    it('mantiene effects distintos como entradas separadas', () => {
+      const actor = mkActor([
+        mkEffect('a', 'Orochi', [{ key: ATTACK_PATH, value: '20', type: 'add' }]),
+        mkEffect('b', 'Berserker', [{ key: ATTACK_PATH, value: '10', type: 'add' }])
+      ]);
+
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toContain('Orochi (+20)');
+      expect(suffix).toContain('Berserker (+10)');
     });
   });
-
+});
+;
+      expect(suffix).toContain('Orochi (+20)');
+      expect(suffix).toContain('Berserker (+10)');
+    });
+  });
 });

--- a/src/module/actor/utils/chatFlavorTrace.integration.test.js
+++ b/src/module/actor/utils/chatFlavorTrace.integration.test.js
@@ -1,0 +1,327 @@
+import { inferAttributeFromFlavor, ATTRIBUTE_DERIVATION_MAP } from './attributeDerivationMap.js';
+import { getActiveEffectsBreakdownForAttribute } from './activeEffectsBreakdown.js';
+import { formatAeBreakdownForFlavor } from './aeBreakdownFormat.js';
+
+/**
+ * End-to-end traceability flow (no Foundry dependencies).
+ *
+ * Simulates exactly what the preCreateChatMessage hook in animabf.mjs does:
+ *   roll flavor -> inferAttributeFromFlavor -> attribute key
+ *   actor + attribute -> getActiveEffectsBreakdownForAttribute -> breakdown
+ *   breakdown -> formatAeBreakdownForFlavor -> HTML suffix
+ *
+ * If this suite passes the hook is guaranteed correct for the cases covered;
+ * the only remaining unknown is the Foundry-side wiring (speaker -> actor
+ * resolution), which is validated manually.
+ */
+
+const ATTACK_PATH = 'system.combat.attack.final.value';
+const PHYSICAL_PATH = 'system.general.modifiers.physicalActions.final.value';
+const ALL_ACTIONS_PATH = 'system.general.modifiers.allActions.final.value';
+const BLOCK_PATH = 'system.combat.block.final.value';
+const DODGE_PATH = 'system.combat.dodge.final.value';
+const INITIATIVE_PATH = 'system.characteristics.secondaries.initiative.final.value';
+const MAGIC_OFFENSIVE_PATH = 'system.mystic.magicProjection.imbalance.offensive.final.value';
+const PSYCHIC_OFFENSIVE_PATH = 'system.psychic.psychicProjection.imbalance.offensive.final.value';
+
+const mkActor = (effects) => ({
+  _source: { system: {} },
+  system: {},
+  effects: { contents: effects }
+});
+
+const mkEffect = (id, name, changes, opts = {}) => ({
+  id,
+  name,
+  active: opts.active ?? true,
+  changes,
+  system: {}
+});
+
+/** End-to-end pipeline: same logic the hook runs. */
+function runFlavorPipeline(actor, flavor) {
+  const attribute = inferAttributeFromFlavor(flavor);
+  if (!attribute) return { attribute: null, breakdown: null, suffix: '' };
+  const breakdown = getActiveEffectsBreakdownForAttribute(actor, attribute);
+  const suffix = formatAeBreakdownForFlavor(breakdown);
+  return { attribute, breakdown, suffix };
+}
+
+describe('end-to-end flavor trace pipeline', () => {
+  describe('Ataque', () => {
+    it('attributes Sangre de Orochi (direct on attack.final) to ataque', () => {
+      const actor = mkActor([
+        mkEffect('orochi', 'Sangre de Orochi', [
+          { key: ATTACK_PATH, value: '20', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(attribute).toBe('attack');
+      expect(suffix).toContain('Sangre de Orochi (+20)');
+    });
+
+    it('attributes Ceguera parcial (indirect via physicalActions) to ataque', () => {
+      const actor = mkActor([
+        mkEffect('ceguera', 'Ceguera parcial', [
+          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(attribute).toBe('attack');
+      expect(suffix).toContain('Ceguera parcial (-30)');
+    });
+
+    it('combines direct and indirect contributors under the same flavor', () => {
+      const actor = mkActor([
+        mkEffect('orochi', 'Sangre de Orochi', [
+          { key: ATTACK_PATH, value: '20', type: 'add' }
+        ]),
+        mkEffect('berserker', 'Berserker', [
+          { key: ATTACK_PATH, value: '10', type: 'add' }
+        ]),
+        mkEffect('ceguera', 'Ceguera parcial', [
+          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
+        ])
+      ]);
+
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toContain('Sangre de Orochi (+20)');
+      expect(suffix).toContain('Berserker (+10)');
+      expect(suffix).toContain('Ceguera parcial (-30)');
+    });
+
+    it('catches the localized weapon-attack flavor', () => {
+      const actor = mkActor([
+        mkEffect('orochi', 'Sangre de Orochi', [
+          { key: ATTACK_PATH, value: '20', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Ataque físico con Hacha de guerra contra Goul');
+      expect(attribute).toBe('attack');
+      expect(suffix).toContain('Sangre de Orochi (+20)');
+    });
+
+    it('ignores effects on unrelated attributes (dodge buff doesn’t pollute ataque)', () => {
+      const actor = mkActor([
+        mkEffect('dodgeBuff', 'Aquarius', [
+          { key: DODGE_PATH, value: '15', type: 'add' }
+        ])
+      ]);
+
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toBe('');
+    });
+
+    it('catches the allActions modifier path too', () => {
+      const actor = mkActor([
+        mkEffect('allMod', 'Some global penalty', [
+          { key: ALL_ACTIONS_PATH, value: '-20', type: 'add' }
+        ])
+      ]);
+
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toContain('Some global penalty (-20)');
+    });
+  });
+
+  describe('Parada y esquiva', () => {
+    it('attributes Ceguera parcial to parada via the shared physicalActions modifier', () => {
+      const actor = mkActor([
+        mkEffect('ceguera', 'Ceguera parcial', [
+          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling parada');
+      expect(attribute).toBe('block');
+      expect(suffix).toContain('Ceguera parcial (-30)');
+    });
+
+    it('attributes Ceguera parcial to esquiva too', () => {
+      const actor = mkActor([
+        mkEffect('ceguera', 'Ceguera parcial', [
+          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling esquiva');
+      expect(attribute).toBe('dodge');
+      expect(suffix).toContain('Ceguera parcial (-30)');
+    });
+
+    it('a dodge-only buff appears under esquiva but not parada', () => {
+      const actor = mkActor([
+        mkEffect('aquarius', 'Aquarius', [
+          { key: DODGE_PATH, value: '15', type: 'add' }
+        ])
+      ]);
+
+      expect(runFlavorPipeline(actor, 'Rolling esquiva').suffix).toContain('Aquarius (+15)');
+      expect(runFlavorPipeline(actor, 'Rolling parada').suffix).toBe('');
+    });
+  });
+
+  describe('Iniciativa', () => {
+    it('attributes Derribado (indirect — initiative penalty)', () => {
+      const actor = mkActor([
+        mkEffect('derribado', 'Derribado', [
+          { key: INITIATIVE_PATH, value: '-10', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Iniciativa');
+      expect(attribute).toBe('initiative');
+      expect(suffix).toContain('Derribado (-10)');
+    });
+  });
+
+  describe('Proyección mágica y psíquica', () => {
+    it('catches the offensive magic projection flavor', () => {
+      const actor = mkActor([
+        mkEffect('seraphite', 'Seraphite', [
+          { key: MAGIC_OFFENSIVE_PATH, value: '30', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling proyección mágica ofensiva');
+      expect(attribute).toBe('magicProjectionOffensive');
+      expect(suffix).toContain('Seraphite (+30)');
+    });
+
+    it('catches the offensive psychic projection flavor', () => {
+      const actor = mkActor([
+        mkEffect('shephon', 'Shephon', [
+          { key: PSYCHIC_OFFENSIVE_PATH, value: '20', type: 'add' }
+        ])
+      ]);
+
+      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling proyección psíquica ofensiva');
+      expect(attribute).toBe('psychicProjectionOffensive');
+      expect(suffix).toContain('Shephon (+20)');
+    });
+
+    it('does not cross-pollinate offensive and defensive projections', () => {
+      const actor = mkActor([
+        mkEffect('something', 'Defensive Buff', [
+          { key: 'system.mystic.magicProjection.imbalance.defensive.final.value', value: '30', type: 'add' }
+        ])
+      ]);
+
+      expect(runFlavorPipeline(actor, 'Rolling proyección mágica ofensiva').suffix).toBe('');
+      expect(runFlavorPipeline(actor, 'Rolling proyección mágica defensiva').suffix).toContain('Defensive Buff (+30)');
+    });
+  });
+
+  describe('Robustez del pipeline', () => {
+    it('returns empty pipeline for unrecognized flavors', () => {
+      const actor = mkActor([
+        mkEffect('orochi', 'Sangre de Orochi', [{ key: ATTACK_PATH, value: '20', type: 'add' }])
+      ]);
+      const res = runFlavorPipeline(actor, 'Some random unrelated chat message');
+      expect(res.attribute).toBeNull();
+      expect(res.suffix).toBe('');
+    });
+
+    it('disabled AE are not listed', () => {
+      const actor = mkActor([
+        mkEffect('orochi', 'Sangre de Orochi',
+          [{ key: ATTACK_PATH, value: '20', type: 'add' }],
+          { active: false })
+      ]);
+      expect(runFlavorPipeline(actor, 'Rolling attack').suffix).toBe('');
+    });
+
+    it('actor with no AE produces no suffix', () => {
+      const actor = mkActor([]);
+      expect(runFlavorPipeline(actor, 'Rolling attack').suffix).toBe('');
+    });
+
+    it('override mode is rendered as non-linear (no signed delta)', () => {
+      const actor = mkActor([
+        mkEffect('shinkyou', 'Shinkyou (Posición Espejo)', [
+          { key: ATTACK_PATH, value: '999', type: 'override' }
+        ])
+      ]);
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toContain('Shinkyou (Posición Espejo) (override)');
+      expect(suffix).toContain('Mod (no descompuesto)');
+    });
+
+    it('multiply mode is rendered as non-linear (no signed delta)', () => {
+      const actor = mkActor([
+        mkEffect('doubler', 'Doubler', [
+          { key: ATTACK_PATH, value: '2', type: 'multiply' }
+        ])
+      ]);
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toContain('Doubler (multiply)');
+    });
+
+    it('Foundry-standard numeric mode 2 (ADD) is treated as linear add', () => {
+      const actor = mkActor([
+        mkEffect('eff', 'Native AE', [
+          { key: ATTACK_PATH, value: '15', mode: 2 }
+        ])
+      ]);
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(suffix).toContain('Native AE (+15)');
+    });
+
+    it('keeps the order in which effects appear on the actor', () => {
+      const actor = mkActor([
+        mkEffect('a', 'A', [{ key: ATTACK_PATH, value: '5', type: 'add' }]),
+        mkEffect('b', 'B', [{ key: ATTACK_PATH, value: '5', type: 'add' }]),
+        mkEffect('c', 'C', [{ key: ATTACK_PATH, value: '5', type: 'add' }])
+      ]);
+      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
+      const order = suffix.indexOf('A (') < suffix.indexOf('B (') &&
+                    suffix.indexOf('B (') < suffix.indexOf('C (');
+      expect(order).toBe(true);
+    });
+
+    it('Sigrid scenario: Orochi + Berserker + Ceguera parcial all listed under attack', () => {
+      const actor = mkActor([
+        mkEffect('orochi', 'Sangre de Orochi - Sangre de la Violencia', [
+          { key: ATTACK_PATH, value: '20', type: 'add' }
+        ]),
+        mkEffect('berserker', 'Berserker', [
+          { key: ATTACK_PATH, value: '10', type: 'add' }
+        ]),
+        mkEffect('ceguera', 'Ceguera parcial', [
+          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
+        ])
+      ]);
+
+      const { suffix, breakdown } = runFlavorPipeline(actor, 'Rolling attack');
+      expect(breakdown.items).toHaveLength(3);
+      expect(breakdown.linearTotal).toBe(0); // 20 + 10 - 30 = 0
+      expect(suffix).toContain('Sangre de Orochi');
+      expect(suffix).toContain('Berserker');
+      expect(suffix).toContain('Ceguera parcial');
+    });
+  });
+
+  describe('Integrity of ATTRIBUTE_DERIVATION_MAP', () => {
+    it('every attribute lists its own final path first', () => {
+      for (const [attr, paths] of Object.entries(ATTRIBUTE_DERIVATION_MAP)) {
+        expect(paths.length).toBeGreaterThan(0);
+        expect(paths[0]).toMatch(/\.final\.value$/);
+      }
+    });
+
+    it('attack, block and dodge share the same modifier set', () => {
+      const sharedMods = [
+        'system.general.modifiers.allActions.final.value',
+        'system.general.modifiers.physicalActions.final.value'
+      ];
+      for (const mod of sharedMods) {
+        expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain(mod);
+        expect(ATTRIBUTE_DERIVATION_MAP.block).toContain(mod);
+        expect(ATTRIBUTE_DERIVATION_MAP.dodge).toContain(mod);
+      }
+    });
+  });
+});

--- a/src/module/actor/utils/chatFlavorTrace.integration.test.js
+++ b/src/module/actor/utils/chatFlavorTrace.integration.test.js
@@ -1,4 +1,4 @@
-import { inferAttributeFromFlavor, ATTRIBUTE_DERIVATION_MAP } from './attributeDerivationMap.js';
+import { inferAttributeFromFlavor } from './attributeDerivationMap.js';
 import { getActiveEffectsBreakdownForAttribute } from './activeEffectsBreakdown.js';
 import { formatAeBreakdownForFlavor } from './aeBreakdownFormat.js';
 
@@ -92,18 +92,6 @@ describe('end-to-end flavor trace pipeline', () => {
       expect(suffix).toContain('Ceguera parcial (-30)');
     });
 
-    it('catches the localized weapon-attack flavor', () => {
-      const actor = mkActor([
-        mkEffect('orochi', 'Sangre de Orochi', [
-          { key: ATTACK_PATH, value: '20', type: 'add' }
-        ])
-      ]);
-
-      const { attribute, suffix } = runFlavorPipeline(actor, 'Ataque físico con Hacha de guerra contra Goul');
-      expect(attribute).toBe('attack');
-      expect(suffix).toContain('Sangre de Orochi (+20)');
-    });
-
     it('ignores effects on unrelated attributes (dodge buff doesn’t pollute ataque)', () => {
       const actor = mkActor([
         mkEffect('dodgeBuff', 'Aquarius', [
@@ -115,16 +103,6 @@ describe('end-to-end flavor trace pipeline', () => {
       expect(suffix).toBe('');
     });
 
-    it('catches the allActions modifier path too', () => {
-      const actor = mkActor([
-        mkEffect('allMod', 'Some global penalty', [
-          { key: ALL_ACTIONS_PATH, value: '-20', type: 'add' }
-        ])
-      ]);
-
-      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
-      expect(suffix).toContain('Some global penalty (-20)');
-    });
   });
 
   describe('Parada y esquiva', () => {
@@ -137,18 +115,6 @@ describe('end-to-end flavor trace pipeline', () => {
 
       const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling parada');
       expect(attribute).toBe('block');
-      expect(suffix).toContain('Ceguera parcial (-30)');
-    });
-
-    it('attributes Ceguera parcial to esquiva too', () => {
-      const actor = mkActor([
-        mkEffect('ceguera', 'Ceguera parcial', [
-          { key: PHYSICAL_PATH, value: '-30', type: 'add' }
-        ])
-      ]);
-
-      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling esquiva');
-      expect(attribute).toBe('dodge');
       expect(suffix).toContain('Ceguera parcial (-30)');
     });
 
@@ -189,18 +155,6 @@ describe('end-to-end flavor trace pipeline', () => {
       const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling proyección mágica ofensiva');
       expect(attribute).toBe('magicProjectionOffensive');
       expect(suffix).toContain('Seraphite (+30)');
-    });
-
-    it('catches the offensive psychic projection flavor', () => {
-      const actor = mkActor([
-        mkEffect('shephon', 'Shephon', [
-          { key: PSYCHIC_OFFENSIVE_PATH, value: '20', type: 'add' }
-        ])
-      ]);
-
-      const { attribute, suffix } = runFlavorPipeline(actor, 'Rolling proyección psíquica ofensiva');
-      expect(attribute).toBe('psychicProjectionOffensive');
-      expect(suffix).toContain('Shephon (+20)');
     });
 
     it('does not cross-pollinate offensive and defensive projections', () => {
@@ -250,38 +204,6 @@ describe('end-to-end flavor trace pipeline', () => {
       expect(suffix).toContain('Mod (no descompuesto)');
     });
 
-    it('multiply mode is rendered as non-linear (no signed delta)', () => {
-      const actor = mkActor([
-        mkEffect('doubler', 'Doubler', [
-          { key: ATTACK_PATH, value: '2', type: 'multiply' }
-        ])
-      ]);
-      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
-      expect(suffix).toContain('Doubler (multiply)');
-    });
-
-    it('Foundry-standard numeric mode 2 (ADD) is treated as linear add', () => {
-      const actor = mkActor([
-        mkEffect('eff', 'Native AE', [
-          { key: ATTACK_PATH, value: '15', mode: 2 }
-        ])
-      ]);
-      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
-      expect(suffix).toContain('Native AE (+15)');
-    });
-
-    it('keeps the order in which effects appear on the actor', () => {
-      const actor = mkActor([
-        mkEffect('a', 'A', [{ key: ATTACK_PATH, value: '5', type: 'add' }]),
-        mkEffect('b', 'B', [{ key: ATTACK_PATH, value: '5', type: 'add' }]),
-        mkEffect('c', 'C', [{ key: ATTACK_PATH, value: '5', type: 'add' }])
-      ]);
-      const { suffix } = runFlavorPipeline(actor, 'Rolling attack');
-      const order = suffix.indexOf('A (') < suffix.indexOf('B (') &&
-                    suffix.indexOf('B (') < suffix.indexOf('C (');
-      expect(order).toBe(true);
-    });
-
     it('Sigrid scenario: Orochi + Berserker + Ceguera parcial all listed under attack', () => {
       const actor = mkActor([
         mkEffect('orochi', 'Sangre de Orochi - Sangre de la Violencia', [
@@ -304,24 +226,4 @@ describe('end-to-end flavor trace pipeline', () => {
     });
   });
 
-  describe('Integrity of ATTRIBUTE_DERIVATION_MAP', () => {
-    it('every attribute lists its own final path first', () => {
-      for (const [attr, paths] of Object.entries(ATTRIBUTE_DERIVATION_MAP)) {
-        expect(paths.length).toBeGreaterThan(0);
-        expect(paths[0]).toMatch(/\.final\.value$/);
-      }
-    });
-
-    it('attack, block and dodge share the same modifier set', () => {
-      const sharedMods = [
-        'system.general.modifiers.allActions.final.value',
-        'system.general.modifiers.physicalActions.final.value'
-      ];
-      for (const mod of sharedMods) {
-        expect(ATTRIBUTE_DERIVATION_MAP.attack).toContain(mod);
-        expect(ATTRIBUTE_DERIVATION_MAP.block).toContain(mod);
-        expect(ATTRIBUTE_DERIVATION_MAP.dodge).toContain(mod);
-      }
-    });
-  });
 });

--- a/src/module/actor/utils/effectFow/applicators/activeEffectApplicator.js
+++ b/src/module/actor/utils/effectFow/applicators/activeEffectApplicator.js
@@ -1,8 +1,40 @@
 // /module/actor/utils/effectFow/applicators/activeEffectApplicator.js
 
+/**
+ * Normalize a change's mode to one of the four operations we know how to
+ * apply: 'add' | 'multiply' | 'override' | 'custom'.
+ *
+ * Active Effect changes can arrive in two shapes:
+ *  - Legacy custom shape: `change.type` is a string ("add", "multiply",
+ *    "override"). This is what items effect persist in
+ *    `system.effectData.changes` and what the in-system flow has historically
+ *    produced.
+ *  - Foundry-standard shape: `change.mode` is a numeric constant per
+ *    CONST.ACTIVE_EFFECT_MODES. Any AE that goes through Foundry's schema
+ *    validation (e.g. created via the native UI, or after a save/load cycle)
+ *    arrives in this shape.
+ *
+ * Accepting both keeps existing data working while also supporting AEs that
+ * use the standard API.
+ *
+ * @param {{type?: string, mode?: number}} change
+ * @returns {'add'|'multiply'|'override'|'custom'}
+ */
+function resolveChangeMode(change) {
+  if (typeof change?.type === 'string') return change.type;
+  switch (change?.mode) {
+    case 1: return 'multiply'; // CONST.ACTIVE_EFFECT_MODES.MULTIPLY
+    case 2: return 'add';      // CONST.ACTIVE_EFFECT_MODES.ADD
+    case 3: return 'override'; // CONST.ACTIVE_EFFECT_MODES.DOWNGRADE -> treated as override
+    case 4: return 'override'; // CONST.ACTIVE_EFFECT_MODES.UPGRADE   -> treated as override
+    case 5: return 'override'; // CONST.ACTIVE_EFFECT_MODES.OVERRIDE
+    default: return 'add';     // CUSTOM (0) or undefined: default to add
+  }
+}
+
 export function applySingleActiveEffectChange(actor, effect, change) {
   const key = change.key;
-  const mode = change.type;
+  const mode = resolveChangeMode(change);
 
   const rawValue =
     typeof actor._applyDynamicEffectValue === 'function'
@@ -32,7 +64,10 @@ export function applySingleActiveEffectChange(actor, effect, change) {
       break;
 
     case 'override':
-      nextValue = rawValue;
+      // If the AE value is a numeric string ("99"), coerce to number so the
+      // resulting field stays numeric and downstream calculations don't break
+      // on string concatenation.
+      nextValue = !Number.isNaN(numericValue) ? numericValue : rawValue;
       break;
 
     default:

--- a/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.js
+++ b/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.js
@@ -22,15 +22,24 @@ function getFlaggedDeps(effect, index) {
 }
 
 /**
- * Maps an ActiveEffect mode to a write kind.
- * - OVERRIDE => overwrite
- * - others   => modify
+ * Maps an ActiveEffect change mode to a write kind.
  *
- * @param {number} mode
+ * Tolerates both formats:
+ *  - legacy custom string mode in `change.type` (e.g. "override", "add"),
+ *    which is what items effect store in `system.effectData.changes` and what
+ *    the in-system custom flow has historically produced.
+ *  - Foundry-standard numeric mode in `change.mode`, used by any AE that
+ *    passes through Foundry's EffectChangeData schema (every AE created via
+ *    Foundry's native UI, or after schema normalization). OVERRIDE = 5 per
+ *    CONST.ACTIVE_EFFECT_MODES.
+ *
+ * @param {{type?: string, mode?: number}} change
  * @returns {'overwrite'|'modify'}
  */
-function writeKindFromAEMode(type) {
-  return type === 'override' ? 'overwrite' : 'modify';
+function writeKindFromAEMode(change) {
+  if (change?.type === 'override') return 'overwrite';
+  if (change?.mode === 5) return 'overwrite'; // CONST.ACTIVE_EFFECT_MODES.OVERRIDE
+  return 'modify';
 }
 
 /**
@@ -47,7 +56,7 @@ export function buildActiveEffectChangeOp(effect, index, change) {
   const deps = normalizePaths([...flagged, ...inferred]);
 
   const [path] = normalizePaths([change.key]);
-  const kind = writeKindFromAEMode(change.type);
+  const kind = writeKindFromAEMode(change);
 
   return {
     id: `ae:${effect.id}:${index}`,
@@ -73,7 +82,14 @@ export function buildActiveEffectChangeOps(actor) {
   for (const effect of actor.effects?.contents ?? []) {
     if (!effect.active) continue;
 
-    const changes = effect.system.changes;
+    // Foundry's ActiveEffect stores changes at the top-level `effect.changes`
+    // (see EffectChangeData schema). The previous reading of
+    // `effect.system.changes` was always empty/undefined because Foundry does
+    // not place changes under the system data; that single line silently broke
+    // every Active Effect in the system (Sangre de Orochi, Ceguera, Derribado,
+    // ...) - they appeared active on the token but their changes were never
+    // applied.
+    const changes = effect.changes;
     if (!Array.isArray(changes) || changes.length === 0) continue;
 
     for (let i = 0; i < changes.length; i++) {

--- a/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
+++ b/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
@@ -1,0 +1,193 @@
+import {
+  buildActiveEffectChangeOp,
+  buildActiveEffectChangeOps
+} from './buildActiveEffectOps.js';
+import { applySingleActiveEffectChange } from '../../applicators/activeEffectApplicator.js';
+
+/**
+ * Regression tests for the bug where Active Effects items were not being
+ * applied to the actor during prepareActor's effect flow.
+ *
+ * Two root causes were identified:
+ *  1. buildActiveEffectChangeOps read `effect.system.changes` instead of the
+ *     Foundry-standard `effect.changes` top-level property, so the loop never
+ *     iterated and zero ops were produced.
+ *  2. The applicator/builder only matched the legacy custom string mode (e.g.
+ *     `change.type === 'add'`) and missed the Foundry-standard numeric
+ *     `change.mode` (CONST.ACTIVE_EFFECT_MODES.ADD = 2). Any AE created
+ *     through Foundry's standard schema validation lost its mode and
+ *     defaulted to the no-op branch.
+ *
+ * Both layers are exercised here so the contract stays honest going forward.
+ */
+
+const mkEffect = (id, changes, { active = true } = {}) => ({
+  id,
+  active,
+  priority: 0,
+  changes,
+  // legacy nested data the OLD builder used to look at — kept null to prove
+  // the new builder no longer relies on it
+  system: {}
+});
+
+describe('buildActiveEffectChangeOps', () => {
+  it('reads changes from effect.changes (top-level), not effect.system.changes', () => {
+    const effect = mkEffect('eff1', [
+      { key: 'system.combat.attack.final.value', value: '20', type: 'add', priority: null }
+    ]);
+
+    const actor = { effects: { contents: [effect] } };
+
+    const ops = buildActiveEffectChangeOps(actor);
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0].id).toBe('ae:eff1:0');
+    expect(ops[0].writes[0].path).toBe('system.combat.attack.final.value');
+  });
+
+  it('skips effects that are not active', () => {
+    const effect = mkEffect(
+      'eff2',
+      [{ key: 'system.combat.attack.final.value', value: '20', type: 'add' }],
+      { active: false }
+    );
+
+    const actor = { effects: { contents: [effect] } };
+
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(0);
+  });
+
+  it('emits one op per change', () => {
+    const effect = mkEffect('eff3', [
+      { key: 'system.combat.attack.final.value', value: '10', type: 'add' },
+      { key: 'system.combat.block.final.value', value: '10', type: 'add' },
+      { key: 'system.combat.dodge.final.value', value: '-30', type: 'add' }
+    ]);
+
+    const actor = { effects: { contents: [effect] } };
+
+    const ops = buildActiveEffectChangeOps(actor);
+    expect(ops).toHaveLength(3);
+  });
+});
+
+describe('applySingleActiveEffectChange', () => {
+  /**
+   * Minimal actor stub: a plain object with a `system` tree we can read/write
+   * with foundry.utils.setProperty/getProperty equivalents (the applicator
+   * uses foundry.utils directly — for this test we shim a tiny global).
+   */
+  const setupGlobalFoundryUtils = () => {
+    const getProperty = (obj, path) =>
+      path.split('.').reduce((o, k) => (o == null ? undefined : o[k]), obj);
+
+    const setProperty = (obj, path, value) => {
+      const keys = path.split('.');
+      let cur = obj;
+      for (let i = 0; i < keys.length - 1; i++) {
+        const k = keys[i];
+        if (cur[k] == null || typeof cur[k] !== 'object') cur[k] = {};
+        cur = cur[k];
+      }
+      cur[keys[keys.length - 1]] = value;
+      return true;
+    };
+
+    globalThis.foundry = {
+      ...(globalThis.foundry ?? {}),
+      utils: { ...(globalThis.foundry?.utils ?? {}), getProperty, setProperty }
+    };
+  };
+
+  beforeAll(setupGlobalFoundryUtils);
+
+  it('adds with legacy string mode (type: "add")', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 50 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      type: 'add',
+      value: '20'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(70);
+  });
+
+  it('adds with Foundry-standard numeric mode (CONST.ACTIVE_EFFECT_MODES.ADD = 2)', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 50 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      mode: 2, // CONST.ACTIVE_EFFECT_MODES.ADD
+      value: '20'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(70);
+  });
+
+  it('multiplies with Foundry-standard numeric mode (MULTIPLY = 1)', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 10 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      mode: 1, // CONST.ACTIVE_EFFECT_MODES.MULTIPLY
+      value: '3'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(30);
+  });
+
+  it('overrides with Foundry-standard numeric mode (OVERRIDE = 5)', () => {
+    const actor = {
+      system: { combat: { attack: { final: { value: 50 } } } },
+      _applyDynamicEffectValue: v => v
+    };
+
+    applySingleActiveEffectChange(actor, {}, {
+      key: 'system.combat.attack.final.value',
+      mode: 5, // CONST.ACTIVE_EFFECT_MODES.OVERRIDE
+      value: '99'
+    });
+
+    expect(actor.system.combat.attack.final.value).toBe(99);
+  });
+});
+
+describe('buildActiveEffectChangeOp writeKind', () => {
+  it('maps the legacy "override" string to overwrite', () => {
+    const op = buildActiveEffectChangeOp({ id: 'x', priority: 0 }, 0, {
+      key: 'system.combat.attack.final.value',
+      type: 'override',
+      value: '99'
+    });
+    expect(op.writes[0].kind).toBe('overwrite');
+  });
+
+  it('maps the Foundry-standard OVERRIDE numeric mode (5) to overwrite', () => {
+    const op = buildActiveEffectChangeOp({ id: 'x', priority: 0 }, 0, {
+      key: 'system.combat.attack.final.value',
+      mode: 5,
+      value: '99'
+    });
+    expect(op.writes[0].kind).toBe('overwrite');
+  });
+
+  it('maps any other mode to modify', () => {
+    const op = buildActiveEffectChangeOp({ id: 'x', priority: 0 }, 0, {
+      key: 'system.combat.attack.final.value',
+      mode: 2,
+      value: '20'
+    });
+    expect(op.writes[0].kind).toBe('modify');
+  });
+});

--- a/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
+++ b/src/module/actor/utils/effectFow/ops/builders/buildActiveEffectOps.test.js
@@ -191,3 +191,61 @@ describe('buildActiveEffectChangeOp writeKind', () => {
     expect(op.writes[0].kind).toBe('modify');
   });
 });
+
+/**
+ * Toggle on/off contract for the builder.
+ *
+ * Documents that the builder honours `effect.active` / `effect.disabled`
+ * correctly: an active effect produces ops, a disabled one produces none,
+ * and flipping the flag on the same actor flips the output.
+ *
+ * Note: the user-reported bug "uncheck the toggle, modifiers keep applying"
+ * was NOT here — it lived in `_getLinkedEffect` (compared item.uuid vs
+ * effect.origin and missed unlinked tokens, so the toggle never reached
+ * the AE). Fixed in findEffectLinkedToItem. These tests stay as a
+ * contract: if the builder ever stops respecting `disabled`, they catch it.
+ */
+describe('buildActiveEffectChangeOps — toggle off scenario', () => {
+  const ATTACK_PATH = 'system.combat.attack.final.value';
+
+  const makeEffect = ({ id, disabled }) => ({
+    id,
+    name: 'Sangre de Orochi',
+    disabled,
+    // Foundry's `effect.active` getter: !disabled && !suppressed
+    get active() {
+      return !this.disabled;
+    },
+    priority: 0,
+    changes: [{ key: ATTACK_PATH, value: '20', type: 'add' }],
+    system: {}
+  });
+
+  it('emits one op when the effect is active (toggle ON)', () => {
+    const actor = { effects: { contents: [makeEffect({ id: 'eff1', disabled: false })] } };
+    const ops = buildActiveEffectChangeOps(actor);
+    expect(ops).toHaveLength(1);
+  });
+
+  it('emits zero ops when the effect is disabled (toggle OFF)', () => {
+    const actor = { effects: { contents: [makeEffect({ id: 'eff1', disabled: true })] } };
+    const ops = buildActiveEffectChangeOps(actor);
+    expect(ops).toHaveLength(0);
+  });
+
+  it('honours the live disabled flag — same actor, flipping the effect', () => {
+    const effect = makeEffect({ id: 'eff1', disabled: false });
+    const actor = { effects: { contents: [effect] } };
+
+    // Initially active
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(1);
+
+    // Simulate the toggle off (the sheet handler does effect.update({disabled: true}))
+    effect.disabled = true;
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(0);
+
+    // And back on
+    effect.disabled = false;
+    expect(buildActiveEffectChangeOps(actor)).toHaveLength(1);
+  });
+});

--- a/src/module/actor/utils/ensureLinkedEffectForItem.js
+++ b/src/module/actor/utils/ensureLinkedEffectForItem.js
@@ -1,0 +1,42 @@
+// /module/actor/utils/ensureLinkedEffectForItem.js
+import { findEffectLinkedToItem } from './findEffectLinkedToItem.js';
+
+/**
+ * Ensure the actor has an ActiveEffect document linked to the given system
+ * "effect" Item. If one already exists (matched via findEffectLinkedToItem)
+ * it is returned unchanged; otherwise a fresh AE is created from the item's
+ * `system.effectData` payload.
+ *
+ * Extracted from ABFActorSheet#_ensureEffectForItem so the same logic can be
+ * triggered from any flow that creates an effect Item on an actor (drop to
+ * a token, macro, programmatic creation), not just from a sheet drop.
+ *
+ * @param {object} actor  Foundry Actor (or token actor).
+ * @param {object} item   Foundry Item of type 'effect'.
+ * @returns {Promise<object|null>} The linked AE, or null on failure.
+ */
+export async function ensureLinkedEffectForItem(actor, item) {
+  if (!actor || !item) return null;
+
+  const existing = findEffectLinkedToItem(actor, item);
+  if (existing) return existing;
+
+  const rawBaseData = item.system?.effectData ?? {};
+  // Drop any stale origin baked into stored data; the new AE must point at
+  // the current item's uuid.
+  const { origin, ...baseData } = rawBaseData;
+
+  const data = foundry.utils.mergeObject(
+    {
+      name: item.name,
+      icon: item.img || 'icons/svg/aura.svg',
+      disabled: !item.system?.active,
+      origin: item.uuid
+    },
+    baseData,
+    { inplace: false }
+  );
+
+  const [created] = await actor.createEmbeddedDocuments('ActiveEffect', [data]);
+  return created ?? null;
+}

--- a/src/module/actor/utils/ensureLinkedEffectForItem.test.js
+++ b/src/module/actor/utils/ensureLinkedEffectForItem.test.js
@@ -1,0 +1,126 @@
+import { ensureLinkedEffectForItem } from './ensureLinkedEffectForItem.js';
+
+/**
+ * Behaviour contract for the helper that materializes an ActiveEffect
+ * document on the actor from a system "effect" Item. Used both from the
+ * sheet (_onDropItem) and from the global createItem hook so dropping an
+ * effect onto a token also creates the AE.
+ */
+
+const setupFoundryUtils = () => {
+  globalThis.foundry = {
+    ...(globalThis.foundry ?? {}),
+    utils: {
+      ...(globalThis.foundry?.utils ?? {}),
+      mergeObject: (a, b, _opts) => ({ ...a, ...b })
+    }
+  };
+};
+
+
+/** Tiny stand-in for jest.fn() — Jest 26 + experimental-vm-modules does not
+ *  always expose `jest` globally in ESM tests, so we roll our own minimal
+ *  spy with `.mock.calls` so the assertions below keep working. */
+function makeSpy(impl) {
+  const calls = [];
+  const fn = async (...args) => {
+    calls.push(args);
+    if (typeof impl === 'function') return impl(...args);
+    return undefined;
+  };
+  fn.mock = { calls };
+  return fn;
+}
+
+describe('ensureLinkedEffectForItem', () => {
+  beforeAll(setupFoundryUtils);
+
+  const makeItem = ({ id = 'I1', name = 'Sangre de Orochi', active = false, effectData = {} } = {}) => ({
+    _id: id,
+    id,
+    uuid: `Actor.A.Item.${id}`,
+    name,
+    img: 'icons/svg/aura.svg',
+    system: { active, effectData }
+  });
+
+  const makeActor = ({ effects = [], createSpy } = {}) => ({
+    effects: { contents: effects },
+    createEmbeddedDocuments: createSpy ?? makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }])
+  });
+
+  it('returns null when actor or item is missing', async () => {
+    expect(await ensureLinkedEffectForItem(null, makeItem())).toBeNull();
+    expect(await ensureLinkedEffectForItem(makeActor(), null)).toBeNull();
+  });
+
+  it('creates an AE on the actor when none is linked yet', async () => {
+    const item = makeItem({
+      effectData: {
+        changes: [{ key: 'system.combat.attack.final.value', value: '20', type: 'add' }]
+      }
+    });
+    const createSpy = makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }]);
+    const actor = makeActor({ createSpy });
+
+    const created = await ensureLinkedEffectForItem(actor, item);
+
+    expect(createSpy.mock.calls).toHaveLength(1);
+    expect(created.origin).toBe('Actor.A.Item.I1');
+    expect(created.disabled).toBe(true); // item.system.active = false
+    expect(created.name).toBe('Sangre de Orochi');
+    expect(created.changes).toEqual([
+      { key: 'system.combat.attack.final.value', value: '20', type: 'add' }
+    ]);
+  });
+
+  it('returns the existing AE without creating a duplicate', async () => {
+    const item = makeItem();
+    const existing = { id: 'AE1', origin: 'Actor.A.Item.I1' };
+    const createSpy = makeSpy();
+    const actor = makeActor({ effects: [existing], createSpy });
+
+    const result = await ensureLinkedEffectForItem(actor, item);
+
+    expect(result).toBe(existing);
+    expect(createSpy.mock.calls).toHaveLength(0);
+  });
+
+  it('finds the existing AE in unlinked tokens via the .Item.<id> tail', async () => {
+    // Token delta uuid form
+    const item = { _id: 'I1', id: 'I1', uuid: 'Scene.S.Token.T.Actor.A.Item.I1', name: 'X', img: '', system: { active: true, effectData: {} } };
+    const existing = { id: 'AE1', origin: 'Actor.A.Item.I1' }; // world-form origin
+    const createSpy = makeSpy();
+    const actor = makeActor({ effects: [existing], createSpy });
+
+    const result = await ensureLinkedEffectForItem(actor, item);
+
+    expect(result).toBe(existing);
+    expect(createSpy.mock.calls).toHaveLength(0);
+  });
+
+  it('respects active=true on the item (creates AE not disabled)', async () => {
+    const item = makeItem({ active: true });
+    const createSpy = makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }]);
+    const actor = makeActor({ createSpy });
+
+    const created = await ensureLinkedEffectForItem(actor, item);
+
+    expect(created.disabled).toBe(false);
+  });
+
+  it('strips any stale origin from item.system.effectData', async () => {
+    const item = makeItem({
+      effectData: {
+        origin: 'Actor.OLD.Item.OLD',
+        changes: []
+      }
+    });
+    const createSpy = makeSpy(async (_type, [data]) => [{ ...data, id: 'AE1' }]);
+    const actor = makeActor({ createSpy });
+
+    const created = await ensureLinkedEffectForItem(actor, item);
+
+    expect(created.origin).toBe('Actor.A.Item.I1');
+  });
+});

--- a/src/module/actor/utils/findEffectLinkedToItem.js
+++ b/src/module/actor/utils/findEffectLinkedToItem.js
@@ -1,0 +1,34 @@
+// /module/actor/utils/findEffectLinkedToItem.js
+
+/**
+ * Find the ActiveEffect on `actor` that was created as the runtime mirror of
+ * `item` (a system "effect" Item).
+ *
+ * The natural matching key is `effect.origin === item.uuid`, but on unlinked
+ * tokens those two values diverge: the item lives in the TokenDocument delta
+ * and carries a UUID prefixed `Scene.<sceneId>.Token.<tokenId>.Actor.<id>.Item.<id>`,
+ * while the AE was created with `origin: item.uuid` at a moment where the
+ * uuid resolved to the world `Actor.<id>.Item.<id>` form. The trailing
+ * `.Item.<id>` segment is stable across both worlds and is what we match on
+ * as a fallback. This restores the link in unlinked tokens so toggle and
+ * delete actions can find and act on the corresponding AE.
+ *
+ * @param {object} actor
+ * @param {object} item
+ * @returns {object|null}
+ */
+export function findEffectLinkedToItem(actor, item) {
+  if (!actor || !item) return null;
+  const effects = actor.effects?.contents ?? actor.effects ?? [];
+  if (!effects.length) return null;
+
+  const directMatch = effects.find(e => e.origin === item.uuid);
+  if (directMatch) return directMatch;
+
+  const itemId = item._id ?? item.id;
+  if (!itemId) return null;
+  const tailMatch = effects.find(e =>
+    typeof e.origin === 'string' && e.origin.endsWith(`.Item.${itemId}`)
+  );
+  return tailMatch ?? null;
+}

--- a/src/module/actor/utils/findEffectLinkedToItem.test.js
+++ b/src/module/actor/utils/findEffectLinkedToItem.test.js
@@ -1,0 +1,68 @@
+import { findEffectLinkedToItem } from './findEffectLinkedToItem.js';
+
+/**
+ * Regression: in unlinked tokens, item.uuid carries a
+ * `Scene.<sceneId>.Token.<tokenId>.Actor.<id>.Item.<itemId>` prefix while
+ * the corresponding AE was created with `origin: item.uuid` resolved at a
+ * moment when it pointed to the world form `Actor.<id>.Item.<itemId>`. A
+ * direct string compare misses the link and the toggle / delete actions
+ * silently no-op against the AE. We match by the trailing `.Item.<itemId>`
+ * segment as a robust fallback.
+ */
+describe('findEffectLinkedToItem', () => {
+  it('returns null when actor or item is missing', () => {
+    expect(findEffectLinkedToItem(null, { uuid: 'x' })).toBeNull();
+    expect(findEffectLinkedToItem({ effects: { contents: [] } }, null)).toBeNull();
+  });
+
+  it('returns null when there are no effects on the actor', () => {
+    const actor = { effects: { contents: [] } };
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    expect(findEffectLinkedToItem(actor, item)).toBeNull();
+  });
+
+  it('matches by exact uuid (the common linked-actor case)', () => {
+    const effect = { origin: 'Actor.A.Item.I' };
+    const actor = { effects: { contents: [effect] } };
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    expect(findEffectLinkedToItem(actor, item)).toBe(effect);
+  });
+
+  it('matches by trailing .Item.<id> when prefixes diverge (unlinked token)', () => {
+    // Item lives in token delta: prefixed uuid.
+    const item = {
+      uuid: 'Scene.S.Token.T.Actor.A.Item.I',
+      _id: 'I'
+    };
+    // AE was created with origin pointing to the world form.
+    const effect = { origin: 'Actor.A.Item.I' };
+    const actor = { effects: { contents: [effect] } };
+
+    expect(findEffectLinkedToItem(actor, item)).toBe(effect);
+  });
+
+  it('does not match a different item id even if prefixes happen to share parts', () => {
+    const item = { uuid: 'Actor.A.Item.I1', _id: 'I1' };
+    const effect = { origin: 'Actor.A.Item.I2' };
+    const actor = { effects: { contents: [effect] } };
+
+    expect(findEffectLinkedToItem(actor, item)).toBeNull();
+  });
+
+  it('prefers the direct uuid match over the tail match when both exist', () => {
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    const direct = { origin: 'Actor.A.Item.I' };
+    const tail = { origin: 'Scene.S.Token.T.Actor.A.Item.I' };
+    const actor = { effects: { contents: [tail, direct] } };
+
+    expect(findEffectLinkedToItem(actor, item)).toBe(direct);
+  });
+
+  it('handles the actor.effects shape both as Foundry collection and as plain array', () => {
+    const item = { uuid: 'Actor.A.Item.I', _id: 'I' };
+    const effect = { origin: 'Actor.A.Item.I' };
+
+    expect(findEffectLinkedToItem({ effects: { contents: [effect] } }, item)).toBe(effect);
+    expect(findEffectLinkedToItem({ effects: [effect] }, item)).toBe(effect);
+  });
+});

--- a/src/module/actor/utils/prepareActor/calculations/actor/combat/mutateCombatData.js
+++ b/src/module/actor/utils/prepareActor/calculations/actor/combat/mutateCombatData.js
@@ -1,15 +1,15 @@
 export const mutateCombatData = data => {
-  // Re-enabled: attack.final must include allActions and physicalActions so
-  // that AE penalizing those modifiers (Ceguera parcial, Derribado,
-  // Amenazado, etc.) actually reach the attack roll. AE that target
-  // attack.final directly (Sangre de Orochi, Berserker, ...) still apply on
-  // top because the flow toposort runs overwrite ops (this function) before
-  // modify ops (the AE 'add' changes) for the same path.
-  data.combat.attack.final.value =
-    data.combat.attack.base.value +
-    data.combat.attack.special.value +
-    data.general.modifiers.allActions.final.value +
-    data.general.modifiers.physicalActions.final.value;
+  // attack.final.value is intentionally NOT calculated here.
+  // physicalActions only applies to secondary skills contested between two
+  // subjects (per the Anima Beyond Fantasy core rules). Combat actions
+  // (attack, block, dodge) are primary skills and do not receive the
+  // physicalActions modifier through this path.
+  // See: rule about "modificador a acciones físicas".
+  // data.combat.attack.final.value =
+  //   data.combat.attack.base.value +
+  //   data.combat.attack.special.value +
+  //   data.general.modifiers.allActions.final.value +
+  //   data.general.modifiers.physicalActions.final.value;
 
   data.combat.block.final.value =
     data.combat.block.base.value +
@@ -29,8 +29,8 @@ export const mutateCombatData = data => {
 
 mutateCombatData.abfFlow = {
   deps: [
-    'system.combat.attack.base.value',
-    'system.combat.attack.special.value',
+    // 'system.combat.attack.base.value',
+    // 'system.combat.attack.special.value',
     'system.combat.block.base.value',
     'system.combat.block.special.value',
     'system.combat.dodge.base.value',
@@ -41,7 +41,7 @@ mutateCombatData.abfFlow = {
     'system.general.modifiers.physicalActions.final.value'
   ],
   mods: [
-    'system.combat.attack.final.value',
+    // 'system.combat.attack.final.value',
     'system.combat.block.final.value',
     'system.combat.dodge.final.value'
     // 'system.combat.damageReduction.final.value'

--- a/src/module/actor/utils/prepareActor/calculations/actor/combat/mutateCombatData.js
+++ b/src/module/actor/utils/prepareActor/calculations/actor/combat/mutateCombatData.js
@@ -1,9 +1,15 @@
 export const mutateCombatData = data => {
-  // data.combat.attack.final.value =
-  //   data.combat.attack.base.value +
-  //   data.combat.attack.special.value +
-  //   data.general.modifiers.allActions.final.value +
-  //   data.general.modifiers.physicalActions.final.value;
+  // Re-enabled: attack.final must include allActions and physicalActions so
+  // that AE penalizing those modifiers (Ceguera parcial, Derribado,
+  // Amenazado, etc.) actually reach the attack roll. AE that target
+  // attack.final directly (Sangre de Orochi, Berserker, ...) still apply on
+  // top because the flow toposort runs overwrite ops (this function) before
+  // modify ops (the AE 'add' changes) for the same path.
+  data.combat.attack.final.value =
+    data.combat.attack.base.value +
+    data.combat.attack.special.value +
+    data.general.modifiers.allActions.final.value +
+    data.general.modifiers.physicalActions.final.value;
 
   data.combat.block.final.value =
     data.combat.block.base.value +
@@ -23,8 +29,8 @@ export const mutateCombatData = data => {
 
 mutateCombatData.abfFlow = {
   deps: [
-    // 'system.combat.attack.base.value',
-    // 'system.combat.attack.special.value',
+    'system.combat.attack.base.value',
+    'system.combat.attack.special.value',
     'system.combat.block.base.value',
     'system.combat.block.special.value',
     'system.combat.dodge.base.value',
@@ -35,7 +41,7 @@ mutateCombatData.abfFlow = {
     'system.general.modifiers.physicalActions.final.value'
   ],
   mods: [
-    // 'system.combat.attack.final.value',
+    'system.combat.attack.final.value',
     'system.combat.block.final.value',
     'system.combat.dodge.final.value'
     // 'system.combat.damageReduction.final.value'

--- a/src/module/actor/utils/prepareActor/prepareActor.js
+++ b/src/module/actor/utils/prepareActor/prepareActor.js
@@ -90,7 +90,7 @@ const DERIVED_DATA_FUNCTIONS = [
   mutateNaturalPenaltyFinal,
   mutatePhysicalModifier,
   mutatePerceptionPenalty,
-  // mutateCombatData,
+  mutateCombatData,
   mutateMovementType,
   mutateMovementDistances,
   //mutateSecondariesData,

--- a/src/module/actor/utils/prepareActor/prepareActor.js
+++ b/src/module/actor/utils/prepareActor/prepareActor.js
@@ -90,7 +90,7 @@ const DERIVED_DATA_FUNCTIONS = [
   mutateNaturalPenaltyFinal,
   mutatePhysicalModifier,
   mutatePerceptionPenalty,
-  mutateCombatData,
+  // mutateCombatData,
   mutateMovementType,
   mutateMovementDistances,
   //mutateSecondariesData,

--- a/src/module/actor/utils/resolveActorForRoll.js
+++ b/src/module/actor/utils/resolveActorForRoll.js
@@ -1,0 +1,77 @@
+// /module/actor/utils/resolveActorForRoll.js
+
+/**
+ * Single source of truth for resolving "which actor owns this roll".
+ *
+ * Both the attack dialog and the chat-message hook need to read the same
+ * actor — the one whose `effects.contents` lists the AE currently applied
+ * to the entity rolling. On unlinked tokens this is the TokenActor (with
+ * its ActorDelta), NOT the world Actor of the directory.
+ *
+ * The helper accepts whatever the caller has at hand (a TokenDocument, a
+ * Token PlaceableObject, a speaker-like object, or just an actor id) and
+ * always returns the actor that has the effects applied.
+ *
+ * @param {Object} options
+ * @param {object} [options.token]    TokenDocument or Token PlaceableObject
+ * @param {string} [options.tokenId]  Token id (used with sceneId)
+ * @param {string} [options.sceneId]  Scene id, mandatory if tokenId is given
+ * @param {string} [options.actorId]  World actor id (fallback)
+ * @returns {object|null}
+ */
+export function resolveActorForRoll({ token, tokenId, sceneId, actorId } = {}) {
+  // 1) Token document or PlaceableObject -> their .actor is the TokenActor
+  //    (with ActorDelta for unlinked tokens).
+  if (token) {
+    const fromToken = token.actor ?? token.document?.actor ?? null;
+    if (fromToken) return fromToken;
+  }
+
+  // 2) Token id (+ optional scene id) -> resolve the TokenDocument and use
+  //    its actor. Foundry's ChatMessage.getSpeaker sometimes returns
+  //    speaker.scene as null even when the token is on a real scene; we
+  //    fall back to the current canvas scene and finally iterate all
+  //    scenes so the resolution does not break on that edge case.
+  if (tokenId) {
+    let tokenDoc = null;
+    if (sceneId) {
+      tokenDoc = game.scenes?.get(sceneId)?.tokens?.get?.(tokenId) ?? null;
+    }
+    if (!tokenDoc && typeof canvas !== 'undefined') {
+      tokenDoc = canvas?.scene?.tokens?.get?.(tokenId) ?? null;
+    }
+    if (!tokenDoc && game.scenes && typeof game.scenes[Symbol.iterator] === 'function') {
+      for (const s of game.scenes) {
+        const t = s.tokens?.get?.(tokenId);
+        if (t) { tokenDoc = t; break; }
+      }
+    }
+    if (tokenDoc?.actor) return tokenDoc.actor;
+  }
+
+  // 3) Actor id fallback -> world actor from the directory. Last resort
+  //    because this is what we DON'T want for unlinked tokens, but we keep
+  //    it for actors without a token in the canvas.
+  if (actorId) {
+    const actor = game.actors?.get?.(actorId);
+    if (actor) return actor;
+  }
+
+  return null;
+}
+
+/**
+ * Convenience wrapper that takes a chat-message-style speaker and returns
+ * the right actor for the trace hook.
+ *
+ * @param {{token?:string, scene?:string, actor?:string}} speaker
+ * @returns {object|null}
+ */
+export function resolveActorFromSpeaker(speaker) {
+  if (!speaker) return null;
+  return resolveActorForRoll({
+    tokenId: speaker.token,
+    sceneId: speaker.scene,
+    actorId: speaker.actor
+  });
+}

--- a/src/module/actor/utils/resolveActorForRoll.test.js
+++ b/src/module/actor/utils/resolveActorForRoll.test.js
@@ -1,0 +1,132 @@
+import { resolveActorForRoll, resolveActorFromSpeaker } from './resolveActorForRoll.js';
+
+const makeTokenDoc = (actor) => ({ actor });
+const makeTokenPlaceable = (actor) => ({ document: { actor } });
+
+describe('resolveActorForRoll', () => {
+  it('returns null when nothing is provided', () => {
+    expect(resolveActorForRoll()).toBeNull();
+    expect(resolveActorForRoll({})).toBeNull();
+  });
+
+  it('prefers a TokenDocument when given', () => {
+    const tokenActor = { id: 'tokenActor', effects: { contents: ['ae1'] } };
+    const tokenDoc = makeTokenDoc(tokenActor);
+
+    expect(resolveActorForRoll({ token: tokenDoc })).toBe(tokenActor);
+  });
+
+  it('handles a Token PlaceableObject (with .document.actor)', () => {
+    const tokenActor = { id: 'tokenActor' };
+    const placeable = makeTokenPlaceable(tokenActor);
+
+    expect(resolveActorForRoll({ token: placeable })).toBe(tokenActor);
+  });
+
+  it('resolves via scene + token id when no token object is passed', () => {
+    const tokenActor = { id: 'tokenActor' };
+    const tokenDoc = makeTokenDoc(tokenActor);
+    const scene = { tokens: { get: (id) => (id === 'T1' ? tokenDoc : null) } };
+    globalThis.game = {
+      scenes: { get: (id) => (id === 'S1' ? scene : null) },
+      actors: { get: () => null }
+    };
+
+    expect(resolveActorForRoll({ tokenId: 'T1', sceneId: 'S1' })).toBe(tokenActor);
+  });
+
+  it('prefers token over actor id when both are present', () => {
+    const tokenActor = { id: 'tokenActor' };
+    const worldActor = { id: 'world' };
+    globalThis.game = {
+      actors: { get: () => worldActor }
+    };
+
+    const tokenDoc = makeTokenDoc(tokenActor);
+    expect(resolveActorForRoll({ token: tokenDoc, actorId: 'A1' })).toBe(tokenActor);
+  });
+
+  it('returns null when token has no actor and no fallback', () => {
+    const tokenDoc = makeTokenDoc(null);
+    globalThis.game = { actors: { get: () => null } };
+    expect(resolveActorForRoll({ token: tokenDoc })).toBeNull();
+  });
+});
+
+describe('resolveActorFromSpeaker', () => {
+  it('returns null for falsy speaker', () => {
+    expect(resolveActorFromSpeaker(null)).toBeNull();
+    expect(resolveActorFromSpeaker(undefined)).toBeNull();
+  });
+
+  it('resolves to TokenActor via scene+token in the speaker', () => {
+    const tokenActor = { id: 'tokenActor', effects: { contents: ['ae'] } };
+    const tokenDoc = makeTokenDoc(tokenActor);
+    const scene = { tokens: { get: (id) => (id === 'T1' ? tokenDoc : null) } };
+    globalThis.game = {
+      scenes: { get: (id) => (id === 'S1' ? scene : null) },
+      actors: { get: () => ({ id: 'shouldNotBeUsed' }) }
+    };
+
+    const speaker = { token: 'T1', scene: 'S1', actor: 'shouldNotBeUsed' };
+    expect(resolveActorFromSpeaker(speaker)).toBe(tokenActor);
+  });
+
+});
+
+
+describe('resolveActorForRoll — sceneId null fallbacks', () => {
+  it('falls back to canvas.scene when sceneId is null', () => {
+    const tokenActor = { id: 'tokenActor' };
+    const tokenDoc = { actor: tokenActor };
+    const canvasScene = { tokens: { get: (id) => (id === 'T1' ? tokenDoc : null) } };
+    globalThis.canvas = { scene: canvasScene };
+    globalThis.game = {
+      scenes: [],
+      actors: { get: () => null }
+    };
+    expect(resolveActorForRoll({ tokenId: 'T1' })).toBe(tokenActor);
+  });
+
+  it('iterates all scenes when neither sceneId nor canvas helps', () => {
+    const tokenActor = { id: 'tokenActor' };
+    const tokenDoc = { actor: tokenActor };
+    const scene1 = { tokens: { get: () => null } };
+    const scene2 = { tokens: { get: (id) => (id === 'T1' ? tokenDoc : null) } };
+
+    globalThis.canvas = { scene: null };
+    globalThis.game = {
+      scenes: [scene1, scene2],
+      actors: { get: () => null }
+    };
+
+    expect(resolveActorForRoll({ tokenId: 'T1' })).toBe(tokenActor);
+  });
+
+  it('still falls back to world actor when no scene contains the token', () => {
+    const worldActor = { id: 'world' };
+    globalThis.canvas = { scene: null };
+    globalThis.game = {
+      scenes: [],
+      actors: { get: (id) => (id === 'A1' ? worldActor : null) }
+    };
+
+    expect(resolveActorForRoll({ tokenId: 'T_unknown', actorId: 'A1' })).toBe(worldActor);
+  });
+});
+
+describe('resolveActorFromSpeaker — Foundry edge case (scene=null)', () => {
+  it('resolves to the TokenActor even when speaker.scene is null', () => {
+    const tokenActor = { id: 'tokenActor', effects: { contents: ['ae'] } };
+    const tokenDoc = { actor: tokenActor };
+    const canvasScene = { tokens: { get: (id) => (id === 'T1' ? tokenDoc : null) } };
+    globalThis.canvas = { scene: canvasScene };
+    globalThis.game = {
+      scenes: [],
+      actors: { get: () => ({ id: 'shouldNotBeUsed' }) }
+    };
+
+    const speaker = { token: 'T1', scene: null, actor: 'shouldNotBeUsed' };
+    expect(resolveActorFromSpeaker(speaker)).toBe(tokenActor);
+  });
+});

--- a/src/module/dialogs/AttackConfigurationDialog.js
+++ b/src/module/dialogs/AttackConfigurationDialog.js
@@ -85,7 +85,13 @@ export class AttackConfigurationDialog extends FormApplication {
   }
 
   get attackerActor() {
-    return this.modalData?.attacker?.token?.actor;
+    // Read the actor through the same resolution that the trace hook
+    // uses, so any unlinked-token delta is read consistently and the
+    // AE applied to the token (not to the world actor of the sidebar)
+    // are visible to the dialog as well.
+    const token = this.modalData?.attacker?.token;
+    if (!token) return this.modalData?.attacker?.actor ?? null;
+    return token.actor ?? token.document?.actor ?? null;
   }
 
   getData() {

--- a/src/module/dialogs/AttackConfigurationDialog.js
+++ b/src/module/dialogs/AttackConfigurationDialog.js
@@ -2,6 +2,8 @@ import { Templates } from '../utils/constants';
 import { ABFConfig } from '../ABFConfig';
 import { ABFAttackData } from '../combat/ABFAttackData';
 import { getSnapshotTargets } from '../actor/utils/getSnapshotTargets.js';
+import { getActiveEffectsBreakdownForPath } from '../actor/utils/activeEffectsBreakdown.js';
+import { formatAeBreakdownForFlavor } from '../actor/utils/aeBreakdownFormat.js';
 ///dialogs/AttackConfigurationDialog.js
 ///actor/utils/getSnapshotTargets.js
 
@@ -162,7 +164,25 @@ export class AttackConfigurationDialog extends FormApplication {
           ? actor.system.general.diceSettings.abilityMasteryDie.value
           : actor.system.general.diceSettings.abilityDie.value;
 
-      const formula = `${die} + ${baseAttack} + ${mod}`;
+      // --- Traceability of Active Effects ----------------------------------
+      // Active Effects (Sangre de Orochi, Cegueras, Derribado...) write to
+      // actor.system.combat.attack.final.value. The weapon's attack.final
+      // already inherits that via calculateWeaponAttack, so the AE delta is
+      // fused inside baseAttack. To restore traceability we split it back
+      // out into its own term in the formula (only when every AE is a
+      // linear add — for multiply/override we leave the formula fused and
+      // just expose the nominal list in the flavor).
+      const aeBreakdown = getActiveEffectsBreakdownForPath(
+        actor,
+        'system.combat.attack.final.value'
+      );
+      const aeContribution = aeBreakdown.hasNonLinear ? 0 : aeBreakdown.linearTotal;
+      const attackPure = baseAttack - aeContribution;
+
+      const formula = aeContribution !== 0
+        ? `${die} + ${attackPure} + ${aeContribution} + ${mod}`
+        : `${die} + ${baseAttack} + ${mod}`;
+
       const roll = new ABFFoundryRoll(formula, actor.system);
       await roll.evaluate({ async: true });
 
@@ -175,9 +195,14 @@ export class AttackConfigurationDialog extends FormApplication {
         ? { ...ChatMessage.getSpeaker({ token: tokenForSpeaker }), alias: tokenName }
         : ChatMessage.getSpeaker({ actor });
 
+      const baseFlavor = 'Rolling attack';
+      const flavor = aeBreakdown.items.length > 0
+        ? `${baseFlavor}${formatAeBreakdownForFlavor(aeBreakdown)}`
+        : baseFlavor;
+
       await roll.toMessage({
         speaker,
-        flavor: 'Rolling attack'
+        flavor
       });
 
       const attackData = ABFAttackData.builder()

--- a/src/module/dialogs/AttackConfigurationDialog.js
+++ b/src/module/dialogs/AttackConfigurationDialog.js
@@ -3,7 +3,6 @@ import { ABFConfig } from '../ABFConfig';
 import { ABFAttackData } from '../combat/ABFAttackData';
 import { getSnapshotTargets } from '../actor/utils/getSnapshotTargets.js';
 import { getActiveEffectsBreakdownForPath } from '../actor/utils/activeEffectsBreakdown.js';
-import { formatAeBreakdownForFlavor } from '../actor/utils/aeBreakdownFormat.js';
 ///dialogs/AttackConfigurationDialog.js
 ///actor/utils/getSnapshotTargets.js
 
@@ -195,14 +194,11 @@ export class AttackConfigurationDialog extends FormApplication {
         ? { ...ChatMessage.getSpeaker({ token: tokenForSpeaker }), alias: tokenName }
         : ChatMessage.getSpeaker({ actor });
 
-      const baseFlavor = 'Rolling attack';
-      const flavor = aeBreakdown.items.length > 0
-        ? `${baseFlavor}${formatAeBreakdownForFlavor(aeBreakdown)}`
-        : baseFlavor;
-
+      // Flavor base only. The preCreateChatMessage hook in animabf.mjs
+      // appends the breakdown of AE that contributed to this roll.
       await roll.toMessage({
         speaker,
-        flavor
+        flavor: 'Rolling attack'
       });
 
       const attackData = ABFAttackData.builder()

--- a/src/module/dialogs/DefenseConfigurationDialog.js
+++ b/src/module/dialogs/DefenseConfigurationDialog.js
@@ -7,6 +7,7 @@ import { updateAttackTargetsFlag } from '../../utils/updateAttackTargetsFlag.js'
 import { getChatVisibilityOptions } from '../utils/chatVisibility.js';
 import ABFFoundryRoll from '../rolls/ABFFoundryRoll.js';
 import { FormulaEvaluator } from '../../utils/formulaEvaluator.js';
+import { defensesCounterCheck } from '../combat/utils/defensesCounterCheck.js';
 
 export class DefenseConfigurationDialog extends FormApplication {
   constructor(object = {}, options = {}) {
@@ -54,6 +55,14 @@ export class DefenseConfigurationDialog extends FormApplication {
 
     const defenderActor = defender.actor;
 
+    // Read defenses counter flag from defender actor. Same source-of-truth used by
+    // CombatDefenseDialog so both flows stay consistent when the actor accumulates
+    // defenses during a round (reset is handled by ABFCombat hooks on turn change).
+    const defensesCounter = defenderActor.getFlag?.(game.animabf.id, 'defensesCounter') || {
+      accumulated: 0,
+      keepAccumulating: true
+    };
+
     const weapons = defenderActor.system?.combat?.weapons ?? [];
     const firstWeapon = weapons[0];
 
@@ -93,7 +102,12 @@ export class DefenseConfigurationDialog extends FormApplication {
         combat: {
           modifier: 0,
           fatigueUsed: 0,
-          multipleDefensesPenalty: 0,
+          // Auto-derive the multiple-defenses penalty from the actor's running counter.
+          // No manual UI override is exposed in this dialog by design: the penalty
+          // is fully driven by the rules (counter -> defensesCounterCheck mapping)
+          // and the dialog only shows the resulting value as a read-only label.
+          multipleDefensesPenalty: defensesCounterCheck(defensesCounter.accumulated),
+          accumulateDefenses: defensesCounter.keepAccumulating,
 
           weaponUsed: initialWeaponUsed,
           weapon: initialWeapon,
@@ -332,10 +346,18 @@ export class DefenseConfigurationDialog extends FormApplication {
 
       const mod = Number(combat?.modifier ?? 0);
       const multiPenalty = Number(combat?.multipleDefensesPenalty ?? 0);
+      const baseValue = Number(defenseAbility.finalBase ?? 0);
 
-      const formula = `${die} + ${
-        Number(defenseAbility.finalBase ?? 0) + mod + multiPenalty
-      }`;
+      // Defense-type specific rules (mirrors RULES in DefenseStrategies.js):
+      // supernatural shields neither apply the multiple-defenses penalty nor
+      // stack into the defenses counter. Block and dodge do both.
+      const isShieldDefense = type === 'shield';
+      const effectiveMultiPenalty = isShieldDefense ? 0 : multiPenalty;
+
+      // Split each contribution into its own term so the Foundry roll tooltip
+      // shows the breakdown: defense ability, situational modifier, and the
+      // multiple-defenses penalty as three traceable parts.
+      const formula = `${die} + ${baseValue} + ${mod} + (${effectiveMultiPenalty})`;
       const roll = new ABFFoundryRoll(formula, actor.system);
       await roll.evaluate({ async: true });
 
@@ -348,9 +370,13 @@ export class DefenseConfigurationDialog extends FormApplication {
         ? { ...ChatMessage.getSpeaker({ token: tokenForSpeaker }), alias: tokenName }
         : ChatMessage.getSpeaker({ actor });
 
+      const defenseLabel = game.i18n.localize(
+        'macros.combat.dialog.defending.defend.title'
+      );
+
       await roll.toMessage({
         speaker,
-        flavor: 'Rolling defense',
+        flavor: defenseLabel,
         rollMode: vis.rollMode
       });
 
@@ -417,6 +443,15 @@ export class DefenseConfigurationDialog extends FormApplication {
         defenseResult: defenseData.toJSON?.() ?? defenseData,
         updatedAt: Date.now()
       });
+
+      // Increment the defender's defenses counter so the next defense in this
+      // round gets the right multi-defense penalty. The actor method respects
+      // the `keepAccumulating` flag; ABFCombat hooks reset the counter when
+      // the round changes. Supernatural-shield defenses do NOT stack (mirrors
+      // RULES.supernaturalShield.stackDefense in DefenseStrategies.js).
+      if (!isShieldDefense && typeof actor?.accumulateDefenses === 'function') {
+        actor.accumulateDefenses(!!combat?.accumulateDefenses);
+      }
 
       await this.close();
     } catch (err) {

--- a/src/module/dialogs/combat/CombatAttackDialog.js
+++ b/src/module/dialogs/combat/CombatAttackDialog.js
@@ -5,7 +5,6 @@ import ABFFoundryRoll from '../../rolls/ABFFoundryRoll';
 import { ABFSettingsKeys } from '../../../utils/registerSettings';
 import { ABFConfig } from '../../ABFConfig';
 import { getActiveEffectsBreakdownForPath } from '../../actor/utils/activeEffectsBreakdown.js';
-import { formatAeBreakdownForFlavor } from '../../actor/utils/aeBreakdownFormat.js';
 
 const getInitialData = (attacker, defender, options = {}) => {
   const combatDistance = !!game.settings.get(
@@ -408,7 +407,11 @@ export class CombatAttackDialog extends FormApplication {
 
         if (this.modalData.attacker.showRoll) {
           const { i18n } = game;
-          const baseFlavor = weapon
+          // Flavor base only. The breakdown of AE that contributed to this
+          // roll is appended automatically by the preCreateChatMessage hook
+          // in animabf.mjs, so the trace is consistent across every roll
+          // site in the system.
+          const flavor = weapon
             ? i18n.format('macros.combat.dialog.physicalAttack.title', {
                 weapon: weapon?.name,
                 target: this.modalData.defender.token.name
@@ -416,13 +419,6 @@ export class CombatAttackDialog extends FormApplication {
             : i18n.format('macros.combat.dialog.physicalAttack.unarmed.title', {
                 target: this.modalData.defender.token.name
               });
-
-          // Append a nominal breakdown of the AE that contributed to the roll
-          // so the GM can audit which effect added or subtracted what,
-          // without having to inspect the actor.
-          const flavor = aeBreakdown.items.length > 0
-            ? `${baseFlavor}${formatAeBreakdownForFlavor(aeBreakdown)}`
-            : baseFlavor;
 
           roll.toMessage({
             speaker: ChatMessage.getSpeaker({ token: this.modalData.attacker.token }),

--- a/src/module/dialogs/combat/CombatAttackDialog.js
+++ b/src/module/dialogs/combat/CombatAttackDialog.js
@@ -4,6 +4,8 @@ import { damageCheck } from '../../combat/utils/damageCheck.js';
 import ABFFoundryRoll from '../../rolls/ABFFoundryRoll';
 import { ABFSettingsKeys } from '../../../utils/registerSettings';
 import { ABFConfig } from '../../ABFConfig';
+import { getActiveEffectsBreakdownForPath } from '../../actor/utils/activeEffectsBreakdown.js';
+import { formatAeBreakdownForFlavor } from '../../actor/utils/aeBreakdownFormat.js';
 
 const getInitialData = (attacker, defender, options = {}) => {
   const combatDistance = !!game.settings.get(
@@ -365,8 +367,33 @@ export class CombatAttackDialog extends FormApplication {
         for (const key in attackerCombatMod)
           combatModifier += attackerCombatMod[key]?.value ?? 0;
 
+        // --- Traceability of Active Effects -------------------------------
+        // Active Effects (Sangre de Orochi, Cegueras, Derribado...) write to
+        // system.combat.attack.final.value directly. When we use that value
+        // in the roll formula their contribution disappears into the total,
+        // losing the breakdown the GM needs to audit a roll.
+        //
+        // To restore traceability we ask the helper how much of the current
+        // attack value comes from AE, and when every AE is a linear `add`
+        // we expose it as its own term in the formula:
+        //   baseDice + counterAttack + attackPure + aeContribution + combatModifier
+        // (with weapon: attackPure = weapon.attack.final - aeContribution,
+        //  because the weapon final already inherits the actor AE.)
+        //
+        // If any AE is multiply/override we keep the formula fused (the
+        // contribution is not a single linear delta we can split safely)
+        // and only expose the nominal list to the chat template.
+        const aeBreakdown = getActiveEffectsBreakdownForPath(
+          this.attackerActor,
+          'system.combat.attack.final.value'
+        );
+        const aeContribution = aeBreakdown.hasNonLinear ? 0 : aeBreakdown.linearTotal;
+        const attackPure = attack - aeContribution;
+
         const baseDice = this.getBaseCombatDiceFormula(this.attackerActor);
-        let formula = `${baseDice} + ${counterAttackBonus} + ${attack} + ${combatModifier}`;
+        let formula = aeContribution !== 0
+          ? `${baseDice} + ${counterAttackBonus} + ${attackPure} + ${aeContribution} + ${combatModifier}`
+          : `${baseDice} + ${counterAttackBonus} + ${attack} + ${combatModifier}`;
 
         if (this.modalData.attacker.withoutRoll) {
           formula = this.removeFirstDiceTerm(formula);
@@ -381,7 +408,7 @@ export class CombatAttackDialog extends FormApplication {
 
         if (this.modalData.attacker.showRoll) {
           const { i18n } = game;
-          const flavor = weapon
+          const baseFlavor = weapon
             ? i18n.format('macros.combat.dialog.physicalAttack.title', {
                 weapon: weapon?.name,
                 target: this.modalData.defender.token.name
@@ -389,6 +416,13 @@ export class CombatAttackDialog extends FormApplication {
             : i18n.format('macros.combat.dialog.physicalAttack.unarmed.title', {
                 target: this.modalData.defender.token.name
               });
+
+          // Append a nominal breakdown of the AE that contributed to the roll
+          // so the GM can audit which effect added or subtracted what,
+          // without having to inspect the actor.
+          const flavor = aeBreakdown.items.length > 0
+            ? `${baseFlavor}${formatAeBreakdownForFlavor(aeBreakdown)}`
+            : baseFlavor;
 
           roll.toMessage({
             speaker: ChatMessage.getSpeaker({ token: this.modalData.attacker.token }),
@@ -432,7 +466,8 @@ export class CombatAttackDialog extends FormApplication {
             projectile,
             attackerCombatMod,
             critDamageBonus: critDamageBonus ?? 0,
-            automaticCrit: !!automaticCrit
+            automaticCrit: !!automaticCrit,
+            activeEffectsBreakdown: aeBreakdown
           }
         });
 
@@ -536,7 +571,8 @@ export class CombatAttackDialog extends FormApplication {
             macro: spell.macro,
             attackerCombatMod,
             critDamageBonus: critDamageBonus ?? 0,
-            automaticCrit: !!automaticCrit
+            automaticCrit: !!automaticCrit,
+            activeEffectsBreakdown: aeBreakdown
           }
         });
 
@@ -655,7 +691,8 @@ export class CombatAttackDialog extends FormApplication {
             macro: power.macro,
             attackerCombatMod,
             critDamageBonus: critDamageBonus ?? 0,
-            automaticCrit: !!automaticCrit
+            automaticCrit: !!automaticCrit,
+            activeEffectsBreakdown: aeBreakdown
           }
         });
 

--- a/src/module/types/effects/EffectItemConfig.js
+++ b/src/module/types/effects/EffectItemConfig.js
@@ -2,6 +2,7 @@
 import { ABFItems } from '../../items/ABFItems';
 import { openSimpleInputDialog } from '../../utils/dialogs/openSimpleInputDialog';
 import { ABFItemConfigFactory } from '../ABFItemConfig';
+import { findEffectLinkedToItem } from '../../actor/utils/findEffectLinkedToItem.js';
 
 export const INITIAL_EFFECT_DATA = {
   active: false,
@@ -75,7 +76,7 @@ export const EffectItemConfig = ABFItemConfigFactory({
     // is high during play. So this onDelete intentionally skips the
     // ABFDialogs.confirm step that the generic delete flow uses for items
     // whose loss is harder to recover (weapons with computed bonuses, etc.).
-    const effect = actor.effects.find(e => e.origin === item.uuid) ?? null;
+    const effect = findEffectLinkedToItem(actor, item);
 
     const ops = [];
     if (effect) {

--- a/src/module/types/effects/EffectItemConfig.js
+++ b/src/module/types/effects/EffectItemConfig.js
@@ -2,7 +2,6 @@
 import { ABFItems } from '../../items/ABFItems';
 import { openSimpleInputDialog } from '../../utils/dialogs/openSimpleInputDialog';
 import { ABFItemConfigFactory } from '../ABFItemConfig';
-import { ABFDialogs } from '../../dialogs/ABFDialogs';
 
 export const INITIAL_EFFECT_DATA = {
   active: false,
@@ -56,29 +55,35 @@ export const EffectItemConfig = ABFItemConfigFactory({
   },
 
   onDelete: async (actor, target) => {
-    const id = target[0]?.dataset?.itemId;
+    // Foundry exposes the ContextMenu callback target as either a jQuery
+    // selector (legacy V13 behaviour) or a raw HTMLElement (V14, also seen
+    // in V13 when foundry.applications.ux.ContextMenu.implementation is
+    // available). Normalize both shapes; previously `target[0]?.dataset`
+    // would silently return undefined under the HTMLElement shape and the
+    // delete action did nothing.
+    const el = target instanceof HTMLElement ? target : target?.[0];
+    const id = el?.dataset?.itemId;
     if (!id) return;
 
     const item = actor.items.get(id);
     if (!item) return;
 
-    ABFDialogs.confirm(
-      game.i18n.localize('dialogs.items.delete.title'),
-      game.i18n.localize('dialogs.items.delete.body'),
-      {
-        onConfirm: async () => {
-          const effect = actor.effects.find(e => e.origin === item.uuid) ?? null;
+    // Effects are transient combat states (Sorpresa, Derribado, Cegueras,
+    // Paralisis...) that the GM toggles on and off many times per fight.
+    // The cost of an accidental delete is low (re-drag from the compendium
+    // takes one drag) and the cost of an extra confirmation dialog per click
+    // is high during play. So this onDelete intentionally skips the
+    // ABFDialogs.confirm step that the generic delete flow uses for items
+    // whose loss is harder to recover (weapons with computed bonuses, etc.).
+    const effect = actor.effects.find(e => e.origin === item.uuid) ?? null;
 
-          const ops = [];
-          if (effect) {
-            ops.push(actor.deleteEmbeddedDocuments('ActiveEffect', [effect.id]));
-          }
-          ops.push(actor.deleteEmbeddedDocuments('Item', [id]));
+    const ops = [];
+    if (effect) {
+      ops.push(actor.deleteEmbeddedDocuments('ActiveEffect', [effect.id]));
+    }
+    ops.push(actor.deleteEmbeddedDocuments('Item', [id]));
 
-          await Promise.all(ops);
-        }
-      }
-    );
+    await Promise.all(ops);
   },
 
   onAttach: async () => {},

--- a/src/module/types/general/ElanPowerItemConfig.js
+++ b/src/module/types/general/ElanPowerItemConfig.js
@@ -106,13 +106,18 @@ export const ElanPowerItemConfig = ABFItemConfigFactory({
     }
   },
   onDelete: async (actor, target) => {
-    const { elanId } = target[0].dataset;
+    // Normalize the ContextMenu target shape: jQuery selector (legacy V13)
+    // vs HTMLElement (V14, and V13 when the new ContextMenu implementation
+    // is available). Without this, the V14 path would throw because
+    // `target[0]` is undefined for HTMLElement.
+    const el = target instanceof HTMLElement ? target : target?.[0];
+    const { elanId } = el?.dataset ?? {};
 
     if (!elanId) {
       throw new Error('Data id missing. Are you sure to set data-elan-id to rows?');
     }
 
-    const { elanPowerId } = target[0].dataset;
+    const { elanPowerId } = el.dataset;
 
     if (!elanPowerId) {
       throw new Error('Data id missing. Are you sure to set data-elan-power-id to rows?');

--- a/src/templates/dialog/combat/defense-config-dialog.hbs
+++ b/src/templates/dialog/combat/defense-config-dialog.hbs
@@ -15,6 +15,24 @@
         inputValue=this.defender.combat.modifier
       }}
 
+      {{#if (is 'eq' this.ui.activeTab 'shield')}}
+        <p class="label defense-count">
+          {{localize 'macros.combat.dialog.defenseCount.exemption.supernaturalShield'}}
+        </p>
+      {{else}}
+        <p class="label defense-count">
+          {{localize 'macros.combat.dialog.defenseCount.title'}}: {{this.defender.combat.multipleDefensesPenalty}}
+        </p>
+      {{/if}}
+
+      {{>
+        "systems/animabf/templates/common/ui/horizontal-titled-input.hbs"
+        title=(localize 'macros.combat.dialog.combat.accumulateDefenses.title')
+        inputType="checkbox"
+        inputName="defender.combat.accumulateDefenses"
+        inputValue=(is 'eq' this.defender.combat.accumulateDefenses true)
+      }}
+
       <nav class="animabf-tabs sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="dodge">{{localize "macros.combat.dialog.dodgeButton.title"}}</a>
         <a class="item" data-tab="block">{{localize "macros.combat.dialog.blockButton.title"}}</a>

--- a/src/utils/chatActionHandlers/defendActionHandler.js
+++ b/src/utils/chatActionHandlers/defendActionHandler.js
@@ -61,7 +61,11 @@ export default async function defendActionHandler(message, _html, dataset) {
 
     const defenseMode =
       defenderToken.actor?.system?.general?.settings?.defenseType?.value;
-    if (defenseMode === 'resistance') {
+    // Both 'resistance' (damage-resistance defenders) and 'mass' (mass-of-enemies
+    // rule defenders) skip the regular defense dialog: no roll, no multi-defense
+    // counter increment, armor still applies. They funnel through the zero-roll
+    // defense helper instead.
+    if (defenseMode === 'resistance' || defenseMode === 'mass') {
       await sendAccumulationZeroDefense({
         defenderToken,
         attackerToken,

--- a/src/utils/chatActionHandlers/defendTargetActionHandler.js
+++ b/src/utils/chatActionHandlers/defendTargetActionHandler.js
@@ -78,7 +78,11 @@ async function defendTargetActionHandler(message, _html, dataset) {
     // Use the stored token key when present, so the flag update hits the correct entry
     const storedTokenKey = targetEntry?.tokenUuid ?? '';
 
-    if (defenseMode === 'resistance') {
+    // Both 'resistance' (damage-resistance defenders) and 'mass' (mass-of-enemies
+    // rule defenders) skip the regular defense dialog: no roll, no multi-defense
+    // counter increment, armor still applies. They funnel through the zero-roll
+    // defense helper instead.
+    if (defenseMode === 'resistance' || defenseMode === 'mass') {
       await sendAccumulationZeroDefense({
         defenderToken,
         attackerToken,


### PR DESCRIPTION
- Las defensas adicionales aplican su penalizador acumulativo de manera automaticamente

- Se quita el diálogo de confirmación porque los effects son
  estados transitorios que se quitan y ponen muchas veces en combate.

- Al tirar un ataque, parada, esquiva, iniciativa o proyección mágica/
  psíquica,etc... el flavor del roll lista los AE que contribuyeron al
  resultado, incluyendo los que penalizan vía modificadores
  intermedios (Ceguera parcial, Derribado, etc.).

- Arrastrar un effect funciona desde cualquier sitio:
  - Al token en el mapa.
  - A la fila del actor en el sidebar
  - A la pestaña de efectos en la ficha (como antes).
  - Desde macros o creación programática.
  
- Las criaturas de masas no tiran dado de defensa 